### PR TITLE
refactor: extract Workspace, slim SfInfo

### DIFF
--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -250,14 +250,6 @@ class Mode(BaseModel):
     QUIET: bool = False
 
 
-class FilePaths(BaseModel, validate_assignment=True):
-    """Resolved filesystem paths used throughout a FileHandler run."""
-
-    TMP_DIR: Path = Field(default_factory=Path)
-    POLJSON: Path = Field(default_factory=Path)
-    LOGJSON: Path = Field(default_factory=Path)
-
-
 def get_md5(path: str | Path) -> str:
     """Compute and return the MD5 hex digest of the file at path."""
     md5 = hashlib.md5()  # noqa: S324

--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -56,10 +56,6 @@ class SfInfo(BaseModel):
     # if converted
     derived_from: Self | None = None
     dest: Path | None = None
-    # paths used during processing, they are not written out
-    path: Path = Field(default_factory=Path, exclude=True)
-    root_folder: Path = Field(default_factory=Path, exclude=True)
-    tdir: Path = Field(default_factory=Path, exclude=True)
 
     def model_post_init(self, context: Any, /) -> None:
         """Derive the fields not provided by siegfried: status, processed_as, md5"""
@@ -88,21 +84,6 @@ class SfInfo(BaseModel):
             puid: str = self.matches[0]["id"]
             return puid
         return None
-
-    def set_processing_paths(self, root_folder: Path, tdir: Path, initial: bool) -> None:
-        """
-        Set root_folder and tdir, and derive the absolute path for this file.
-        On the initial run (scanned by pygfried), filename is made relative to root_folder.
-        When read from an existing log (initial=False), filename is already relative.
-        """
-        if root_folder.is_file():
-            root_folder = root_folder.parent
-        self.root_folder = root_folder
-        self.tdir = tdir
-        if initial:
-            self.filename = self.filename.parent.relative_to(root_folder) / self.filename.name
-        if not self.dest:
-            self.path = self.root_folder / self.filename
 
 
 class LogOutput(BaseModel):

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -14,7 +14,6 @@ from typer import colors, secho
 
 from fileidentification.definitions.models import (
     BasicAnalytics,
-    FilePaths,
     LogMsg,
     LogOutput,
     LogTables,
@@ -38,7 +37,7 @@ from fileidentification.tasks.conversion import convert_file
 from fileidentification.tasks.inspection import assert_file_integrity, inspect_file
 from fileidentification.tasks.os_tasks import move_tmp, set_filepaths
 from fileidentification.tasks.policies import apply_policy, build_policies
-from fileidentification.workspace import Workspace
+from fileidentification.workspace import FilePaths, Workspace
 from fileidentification.wrappers.tools import tool_for
 
 

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -38,6 +38,7 @@ from fileidentification.tasks.conversion import convert_file
 from fileidentification.tasks.inspection import assert_file_integrity, inspect_file
 from fileidentification.tasks.os_tasks import move_tmp, set_filepaths
 from fileidentification.tasks.policies import apply_policy, build_policies
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import tool_for
 
 
@@ -51,6 +52,7 @@ class FileHandler:
         self.ba = BasicAnalytics()
         self.stack: list[SfInfo] = []
         self.fp: FilePaths = FilePaths()
+        self.ws: Workspace = Workspace(Path(), Path())  # replaced in run() once root_folder / tmp are resolved
         self._stack_lock = threading.Lock()
         self._soffice_lock = threading.Semaphore(1)
 
@@ -60,14 +62,13 @@ class FileHandler:
         Checks whether a log json at default location exists. if so, it adds the sfinfos to the stack from there,
         otherwhise it scans the root_folder with pygfried and adds its output as sfinfos to the stack
         """
-        initial = True
         # if there is a log, try to read from there
         if self.fp.LOGJSON.is_file():
-            initial = False
             self.stack.extend([SfInfo(**metadata) for metadata in json.loads(self.fp.LOGJSON.read_text())["files"]])
 
-        # else scan the root_folder with pygfried
-        if not self.stack:
+        # scan the root_folder with pygfried only when nothing was reloaded; those files then need relativizing
+        initial = not self.stack
+        if initial:
             with Progress(
                 SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True
             ) as prog:
@@ -78,10 +79,10 @@ class FileHandler:
                     scanned = pygfried.identify_dir(f"{root_folder}", workers=PYG_WORKERS)["files"]
                 self.stack.extend(SfInfo(**sfi) for sfi in scanned)  # type: ignore[arg-type]
 
-        # append path values run basic analytics
+        # relativize freshly scanned filenames (portable form), run basic analytics
         for sfinfo in self.stack:
-            if not sfinfo.status.removed:
-                sfinfo.set_processing_paths(root_folder, self.fp.TMP_DIR, initial=initial)
+            if initial and not sfinfo.status.removed:
+                sfinfo.filename = self.ws.relativize(sfinfo.filename)
             if not (sfinfo.status.removed or sfinfo.dest):
                 self.ba.append(sfinfo)
 
@@ -180,10 +181,11 @@ class FileHandler:
                 # we want the smallest file first for running the test
                 sample = self.ba.smallest_file(puid)
                 secho(f"\n{puid}", fg=colors.YELLOW)
-                t_sfinfo, cmd, _ = convert_file(sample, self.policies)
+                t_sfinfo, cmd, _ = convert_file(sample, self.policies, self.ws)
                 if t_sfinfo:
                     secho(f"{cmd}", fg=colors.GREEN, bold=True)
-                    secho(f"You find the file with the log in {t_sfinfo.filename.parent}")
+                    # the test output is not moved, so it lives in the sample's working dir
+                    secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
 
     def inspect(self) -> None:
         """
@@ -198,7 +200,7 @@ class FileHandler:
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 list(
                     executor.map(
-                        lambda sfinfo: inspect_file(sfinfo, self.policies, self.log_tables, self.mode.VERBOSE),
+                        lambda sfinfo: inspect_file(sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE),
                         active,
                     )
                 )
@@ -213,7 +215,9 @@ class FileHandler:
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 list(
                     executor.map(
-                        lambda sfinfo: assert_file_integrity(sfinfo, self.policies, self.log_tables, self.mode.VERBOSE),
+                        lambda sfinfo: assert_file_integrity(
+                            sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE
+                        ),
                         active,
                     )
                 )
@@ -239,7 +243,7 @@ class FileHandler:
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 list(
                     executor.map(
-                        lambda sfinfo: apply_policy(sfinfo, self.policies, self.log_tables, self.mode.STRICT),
+                        lambda sfinfo: apply_policy(sfinfo, self.policies, self.ws, self.log_tables, self.mode.STRICT),
                         active,
                     )
                 )
@@ -257,11 +261,10 @@ class FileHandler:
             tool = tool_for(self.policies[sfinfo.processed_as].bin)  # type: ignore[index]
             ctx = self._soffice_lock if tool and tool.serialized_run else nullcontext()
             with ctx:
-                conv_sfinfo, cmd, bin_log = convert_file(sfinfo, self.policies)
+                conv_sfinfo, cmd, bin_log = convert_file(sfinfo, self.policies, self.ws)
             if conv_sfinfo:
-                msg = f"converted -> {sfinfo.tdir.stem}/{conv_sfinfo.filename.parent.name}/{conv_sfinfo.filename.name}"
+                msg = f"converted -> {conv_sfinfo.filename}"
                 sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=msg))
-                conv_sfinfo.root_folder = sfinfo.root_folder
                 with self._stack_lock:
                     self.stack.append(conv_sfinfo)
             else:
@@ -280,7 +283,7 @@ class FileHandler:
         # move converted files from the working dir to its destination
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
             prog.add_task(description="Moving files ...", total=None)
-            files_moved = move_tmp(self.stack, self.policies, self.log_tables, self.mode.REMOVEORIGINAL)
+            files_moved = move_tmp(self.stack, self.ws, self.policies, self.log_tables, self.mode.REMOVEORIGINAL)
 
         # remove empty folders in working dir
         if self.fp.TMP_DIR.is_dir():
@@ -327,6 +330,8 @@ class FileHandler:
         root_folder = Path(root_folder)
         # set dirs / paths
         set_filepaths(self.fp, root_folder, tmp_dir)
+        # the per-run path calculator (root_folder is normalized to the parent dir for a single-file target)
+        self.ws = Workspace(root_folder, self.fp.TMP_DIR)
         # set the mode
         self.mode.REMOVEORIGINAL = remove_original
         self.mode.VERBOSE = mode_verbose

--- a/fileidentification/tasks/conversion.py
+++ b/fileidentification/tasks/conversion.py
@@ -5,15 +5,20 @@ import pygfried
 from fileidentification.definitions.models import LogMsg, Policies, PolicyParams, SfInfo
 from fileidentification.definitions.settings import FPMsg
 from fileidentification.tasks.console_output import print_conversion_failed_error, print_unexpected_format_error
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.converter import convert
 from fileidentification.wrappers.tools import MediaTool, tool_for
 
 
-def _add_media_info(sfinfo: SfInfo, tool: MediaTool | None) -> None:
-    """Attach technical metadata (codec/stream info) of the converted file to sfinfo.media_info, if tool supports it."""
+def _add_media_info(sfinfo: SfInfo, tool: MediaTool | None, path: Path) -> None:
+    """
+    Attach technical metadata (codec/stream info) of the converted file to sfinfo.media_info, if tool supports it.
+    `path` is the physical location of the file to probe (the working-dir output), not sfinfo.filename, which by
+    now holds the file's future relative home.
+    """
     if tool is None:
         return
-    media_info = tool.media_info(sfinfo.filename)
+    media_info = tool.media_info(path)
     if media_info:
         sfinfo.media_info.append(media_info)
 
@@ -32,6 +37,9 @@ def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
         # only add postprocessing information if conversion was successful
         if target_sfinfo.processed_as in expected:
             target_sfinfo.dest = sfinfo.filename.parent
+            # normalize the converted file to its portable relative home straight away; the physical file still
+            # sits in the working dir until move_tmp (reachable via ws.working_file(derived_from, filename.name)).
+            target_sfinfo.filename = sfinfo.filename.parent / target.name
             target_sfinfo.derived_from = sfinfo
             sfinfo.status.pending = False
 
@@ -50,7 +58,7 @@ def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
 
 
 # file migration
-def convert_file(sfinfo: SfInfo, policies: Policies) -> tuple[SfInfo | None, list[str], LogMsg | None]:
+def convert_file(sfinfo: SfInfo, policies: Policies, ws: Workspace) -> tuple[SfInfo | None, list[str], LogMsg | None]:
     """
     Convert a file according to its policy, then re-identify and verify the output.
     Returns (target_sfinfo, [cmd], bin_log): target_sfinfo is the SfInfo of the verified converted file, or None
@@ -61,18 +69,18 @@ def convert_file(sfinfo: SfInfo, policies: Policies) -> tuple[SfInfo | None, lis
     args: PolicyParams = policies[sfinfo.processed_as]  # type: ignore[index]
     tool = tool_for(args.bin)
 
-    target_path, cmd, logtext = convert(sfinfo, args)
+    target_path, cmd, logtext = convert(sfinfo, args, ws)
 
     # strip abs paths from log output
     processing_log = None
-    logtext = logtext.replace(f"{sfinfo.root_folder}/", "").replace(f"{sfinfo.tdir}/", "")
+    logtext = logtext.replace(f"{ws.root_folder}/", "").replace(f"{ws.tdir}/", "")
     if logtext:
         processing_log = LogMsg(name=f"{args.bin}", msg=logtext)
 
     # create an SfInfo for target and verify output, add codec and processing logs
     target_sfinfo = _verify(target_path, sfinfo, args.expected)
     if target_sfinfo:
-        _add_media_info(target_sfinfo, tool)
+        _add_media_info(target_sfinfo, tool, target_path)
         if processing_log:
             target_sfinfo.processing_logs.append(processing_log)
         processing_log = None  # consumed by the successful target; nothing left for the caller

--- a/fileidentification/tasks/inspection.py
+++ b/fileidentification/tasks/inspection.py
@@ -6,27 +6,32 @@ from fileidentification.tasks.console_output import (
     print_os_error,
 )
 from fileidentification.tasks.os_tasks import remove
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import MediaTool, tool_for, tool_from_mime
 
 
-def assert_file_integrity(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, verbose: bool) -> None:
+def assert_file_integrity(
+    sfinfo: SfInfo, policies: Policies, ws: Workspace, log_tables: LogTables, verbose: bool
+) -> None:
     """
     Probe the file and act on the result: remove it if corrupt, rename it if the extension is wrong.
     If the format has only one known extension, the rename is done automatically;
     otherwise a manual rename warning is printed.
     """
-    res: FDMsg | None = inspect_file(sfinfo, policies, log_tables, verbose)
+    res: FDMsg | None = inspect_file(sfinfo, policies, ws, log_tables, verbose)
     if res == FDMsg.ERROR:
-        remove(sfinfo, log_tables)
+        remove(sfinfo, ws, log_tables)
     if res == FDMsg.EXTMISMATCH:
         if len(FMT2EXT[sfinfo.processed_as]["file_extensions"]) == 1:  # type: ignore[index]
             ext = "." + FMT2EXT[sfinfo.processed_as]["file_extensions"][-1]  # type: ignore[index]
-            _rename(sfinfo, ext, log_tables)
+            _rename(sfinfo, ext, ws, log_tables)
         else:
             print_manual_rename_warning(sfinfo.filename, sfinfo.processing_logs[0].msg)
 
 
-def inspect_file(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, verbose: bool) -> FDMsg | None:
+def inspect_file(
+    sfinfo: SfInfo, policies: Policies, ws: Workspace, log_tables: LogTables, verbose: bool
+) -> FDMsg | None:
     """
     Probe the file without making any filesystem changes.
     Returns ERROR if the file is corrupt, EXTMISMATCH if the extension is wrong, or None if the file is OK.
@@ -47,7 +52,7 @@ def inspect_file(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, verb
                 sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=msgm))
                 break
     # check if the file throws any error, warnings while open/processing it with the respective tool
-    if _has_error(sfinfo, tool, log_tables, verbose):
+    if _has_error(sfinfo, tool, ws, log_tables, verbose):
         return FDMsg.ERROR
 
     if sfinfo.errors == FDMsg.EMPTYSOURCE:
@@ -65,26 +70,27 @@ def inspect_file(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, verb
     return None
 
 
-def _rename(sfinfo: SfInfo, ext: str, log_tables: LogTables) -> None:
+def _rename(sfinfo: SfInfo, ext: str, ws: Workspace, log_tables: LogTables) -> None:
     """
-    Rename the file on disk to the given extension and update sfinfo.path and sfinfo.filename.
+    Rename the file on disk to the given extension and update sfinfo.filename to the new portable relative path.
     If a file with the target name already exists, the MD5 prefix is appended to avoid collision.
     """
-    dest = sfinfo.path.with_suffix(ext)
+    source = ws.abs_path(sfinfo.filename)
+    dest = source.with_suffix(ext)
     # if a file with same name and extension already there, append file hash to name
     if dest.is_file():
-        dest = sfinfo.path.parent / f"{sfinfo.path.stem}_{sfinfo.md5[:6]}{ext}"
+        dest = source.parent / f"{source.stem}_{sfinfo.md5[:6]}{ext}"
     try:
-        sfinfo.path.rename(dest)
-        msg = f"did rename {sfinfo.path.name} -> {dest.name}"
-        sfinfo.path, sfinfo.filename = dest, dest.relative_to(sfinfo.root_folder)
+        source.rename(dest)
+        msg = f"did rename {source.name} -> {dest.name}"
+        sfinfo.filename = ws.relativize(dest)
         sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=msg))
     except OSError as e:
         print_os_error(str(e))
         log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
 
-def _has_error(sfinfo: SfInfo, tool: MediaTool | None, log_tables: LogTables, verbose: bool) -> bool:
+def _has_error(sfinfo: SfInfo, tool: MediaTool | None, ws: Workspace, log_tables: LogTables, verbose: bool) -> bool:
     """
     Probe the file with the given tool and interpret the result.
     :param tool: the MediaTool used to probe the file; None or a non-probing tool (soffice) means no test.
@@ -95,7 +101,7 @@ def _has_error(sfinfo: SfInfo, tool: MediaTool | None, log_tables: LogTables, ve
     # TODO: inspection for other files than Audio/Video/IMAGE
     if tool is None:
         return False
-    result = tool.probe(sfinfo.path, verbose)
+    result = tool.probe(ws.abs_path(sfinfo.filename), verbose)
     if result is None:
         return False
 

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -2,10 +2,10 @@ import shutil
 import sys
 from pathlib import Path
 
-from fileidentification.definitions.models import FilePaths, LogMsg, LogTables, Policies, SfInfo
+from fileidentification.definitions.models import LogMsg, LogTables, Policies, SfInfo
 from fileidentification.definitions.settings import LOGJSON, POLJSON, TMP_DIR
 from fileidentification.tasks.console_output import print_os_error, print_root_not_found
-from fileidentification.workspace import Workspace
+from fileidentification.workspace import FilePaths, Workspace
 
 
 def remove(sfinfo: SfInfo, ws: Workspace, log_tables: LogTables) -> None:

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -3,16 +3,17 @@ import sys
 from pathlib import Path
 
 from fileidentification.definitions.models import FilePaths, LogMsg, LogTables, Policies, SfInfo
-from fileidentification.definitions.settings import LOGJSON, POLJSON, RMV_DIR, TMP_DIR
+from fileidentification.definitions.settings import LOGJSON, POLJSON, TMP_DIR
 from fileidentification.tasks.console_output import print_os_error, print_root_not_found
+from fileidentification.workspace import Workspace
 
 
-def remove(sfinfo: SfInfo, log_tables: LogTables) -> None:
-    """Move a file from its sfinfo path to tmp dir / _REMOVED / ..."""
-    dest: Path = sfinfo.tdir / RMV_DIR / sfinfo.filename
+def remove(sfinfo: SfInfo, ws: Workspace, log_tables: LogTables) -> None:
+    """Move a file from its location to tmp dir / _REMOVED / ..."""
+    dest = ws.removed_dest(sfinfo.filename)
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        shutil.move(sfinfo.path, dest)
+        shutil.move(ws.abs_path(sfinfo.filename), dest)
         sfinfo.status.removed = True
         #  sfinfo.processing_logs.append(LogMsg(name="filehandler", msg="file removed"))
     except OSError as e:
@@ -20,7 +21,9 @@ def remove(sfinfo: SfInfo, log_tables: LogTables) -> None:
         log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
 
-def move_tmp(stack: list[SfInfo], policies: Policies, log_tables: LogTables, remove_original: bool) -> bool:
+def move_tmp(
+    stack: list[SfInfo], ws: Workspace, policies: Policies, log_tables: LogTables, remove_original: bool
+) -> bool:
     """
     Move converted files from the tmp working directory next to their originals.
     If remove_original is set (or the policy has remove_original=True), the source file is moved to _REMOVED.
@@ -35,19 +38,20 @@ def move_tmp(stack: list[SfInfo], policies: Policies, log_tables: LogTables, rem
             # remove the original if its mentioned and flag it accordingly
             if policies[sfinfo.derived_from.processed_as].remove_original or remove_original:  # type: ignore[index, union-attr]
                 derived_from = next(sfi for sfi in stack if sfi.filename == sfinfo.derived_from.filename)  # type: ignore[union-attr]
-                if derived_from.path.is_file():
-                    remove(derived_from, log_tables)
-            # create absolute filepath
-            abs_dest = sfinfo.root_folder / sfinfo.dest / sfinfo.filename.name
+                if ws.abs_path(derived_from.filename).is_file():
+                    remove(derived_from, ws, log_tables)
+            # the converted file still sits in its working dir; its final home is abs_path(filename)
+            source = ws.working_file(sfinfo.derived_from.filename, sfinfo.filename.name)  # type: ignore[union-attr]
+            abs_dest = ws.abs_path(sfinfo.filename)
             # append hash to filename if the path already exists
             if abs_dest.is_file():
-                abs_dest = Path(abs_dest.parent, f"{sfinfo.filename.stem}_{sfinfo.md5[:6]}{sfinfo.filename.suffix}")
+                abs_dest = abs_dest.parent / f"{sfinfo.filename.stem}_{sfinfo.md5[:6]}{sfinfo.filename.suffix}"
             # move the file
             try:
-                shutil.move(sfinfo.filename, abs_dest)
-                if sfinfo.filename.parent.is_dir():
-                    shutil.rmtree(sfinfo.filename.parent)
-                # set relative path in sfinfo.filename, set flags
+                shutil.move(source, abs_dest)
+                if source.parent.is_dir():
+                    shutil.rmtree(source.parent)
+                # set the (possibly collision-renamed) relative path in sfinfo.filename, set flags
                 sfinfo.filename = sfinfo.dest / abs_dest.name
                 sfinfo.status.added = True
                 sfinfo.dest = None

--- a/fileidentification/tasks/policies.py
+++ b/fileidentification/tasks/policies.py
@@ -4,6 +4,7 @@ from fileidentification.definitions.models import LogMsg, LogTables, Mode, Polic
 from fileidentification.definitions.settings import FMT2EXT, PLMsg
 from fileidentification.tasks.console_output import print_invalid_streams_error
 from fileidentification.tasks.os_tasks import remove
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.ffmpeg import ffmpeg_media_info
 
 
@@ -54,7 +55,7 @@ def build_policies(
     return policies, blank_puids
 
 
-def apply_policy(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, strict: bool) -> None:
+def apply_policy(sfinfo: SfInfo, policies: Policies, ws: Workspace, log_tables: LogTables, strict: bool) -> None:
     """
     Decide what to do with the file based on its policy entry.
     Sets sfinfo.status.pending=True if the file needs conversion.
@@ -72,7 +73,7 @@ def apply_policy(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, stri
         # in strict mode, move file
         if strict:
             sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{PLMsg.NOTINPOLICIES}"))
-            remove(sfinfo, log_tables)
+            remove(sfinfo, ws, log_tables)
             return
         # just flag it as skipped
         sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{PLMsg.SKIPPED}"))
@@ -84,14 +85,14 @@ def apply_policy(sfinfo: SfInfo, policies: Policies, log_tables: LogTables, stri
         return
 
     # check if mp4 / mkv has correct stream (i.e. h264 and aac)
-    if puid in ["fmt/199", "fmt/569"] and _has_invalid_streams(sfinfo, puid):
+    if puid in ["fmt/199", "fmt/569"] and _has_invalid_streams(sfinfo, puid, ws):
         sfinfo.status.pending = True
         return
 
 
-def _has_invalid_streams(sfinfo: SfInfo, puid: str) -> bool:
+def _has_invalid_streams(sfinfo: SfInfo, puid: str, ws: Workspace) -> bool:
     """Return true if video and audio codec differ from archival standards"""
-    streams = ffmpeg_media_info(sfinfo.path)
+    streams = ffmpeg_media_info(ws.abs_path(sfinfo.filename))
     if not streams:
         print_invalid_streams_error(sfinfo.filename)
         return False

--- a/fileidentification/workspace.py
+++ b/fileidentification/workspace.py
@@ -1,15 +1,27 @@
 """
-Constructed fresh each run from the CLI root_folder and the tmp dir; never persisted. Portability comes
-from the relative `filename` stored in _log.json — the Workspace only resolves that portable name against
-wherever the run happens to be right now. `tdir` may live on a different volume (--tmp-dir / external drive),
-so it is kept independent of root_folder.
+Run-scoped path types: FilePaths (the resolved tmp dir + its two JSON files) and Workspace (the path calculator).
+
+The Workspace is constructed fresh each run from the CLI root_folder and the tmp dir; never persisted.
+Portability comes from the relative `filename` stored in _log.json — the Workspace only resolves that portable
+name against wherever the run happens to be right now. `tdir` may live on a different volume (--tmp-dir /
+external drive), so it is kept independent of root_folder.
 """
 
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic import BaseModel, Field
+
 from fileidentification.definitions.settings import RMV_DIR
+
+
+class FilePaths(BaseModel, validate_assignment=True):
+    """Resolved output paths used throughout a FileHandler run (the tmp dir and the two JSON files in it)."""
+
+    TMP_DIR: Path = Field(default_factory=Path)
+    POLJSON: Path = Field(default_factory=Path)
+    LOGJSON: Path = Field(default_factory=Path)
 
 
 @dataclass(frozen=True)

--- a/fileidentification/workspace.py
+++ b/fileidentification/workspace.py
@@ -1,0 +1,50 @@
+"""
+Constructed fresh each run from the CLI root_folder and the tmp dir; never persisted. Portability comes
+from the relative `filename` stored in _log.json — the Workspace only resolves that portable name against
+wherever the run happens to be right now. `tdir` may live on a different volume (--tmp-dir / external drive),
+so it is kept independent of root_folder.
+"""
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from fileidentification.definitions.settings import RMV_DIR
+
+
+@dataclass(frozen=True)
+class Workspace:
+    """Maps a file's portable relative `filename` to its absolute, working, and removed locations on disk."""
+
+    root_folder: Path
+    tdir: Path
+
+    def __post_init__(self) -> None:
+        # single-file target: the files live in the parent dir (the normalization set_processing_paths did).
+        # frozen dataclass -> object.__setattr__
+        if self.root_folder.is_file():
+            object.__setattr__(self, "root_folder", self.root_folder.parent)
+
+    def relativize(self, scanned: Path) -> Path:
+        """Make a freshly scanned absolute path relative to root_folder (the portable form persisted in _log.json)."""
+        return scanned.parent.relative_to(self.root_folder) / scanned.name
+
+    def abs_path(self, filename: Path) -> Path:
+        """Absolute location of a file given its portable relative filename."""
+        return self.root_folder / filename
+
+    def working_dir(self, filename: Path) -> Path:
+        """
+        Per-file conversion working dir under tdir. The md5 of the relative path keeps duplicate files
+        with the same basename at different paths from colliding.
+        """
+        path_hash = hashlib.md5(str(filename).encode()).hexdigest()[:6]  # noqa: S324
+        return self.tdir / f"{filename.name}_{path_hash}"
+
+    def working_file(self, origin_filename: Path, output_name: str) -> Path:
+        """Where a converted file physically sits before it is moved: inside its origin's working dir."""
+        return self.working_dir(origin_filename) / output_name
+
+    def removed_dest(self, filename: Path) -> Path:
+        """Location under _REMOVED for a corrupt / replaced file (the relative subpath is preserved)."""
+        return self.tdir / RMV_DIR / filename

--- a/fileidentification/wrappers/converter.py
+++ b/fileidentification/wrappers/converter.py
@@ -1,13 +1,13 @@
-import hashlib
 import shlex
 import subprocess
 from pathlib import Path
 
 from fileidentification.definitions.models import PolicyParams, SfInfo
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import tool_for
 
 
-def convert(sfinfo: SfInfo, args: PolicyParams) -> tuple[Path, str, str]:
+def convert(sfinfo: SfInfo, args: PolicyParams, ws: Workspace) -> tuple[Path, str, str]:
     """
     Convert a file to the desired format passed by the args.
     :param args: how to convert the file ('bin', 'processing_args', 'target_container')
@@ -18,14 +18,13 @@ def convert(sfinfo: SfInfo, args: PolicyParams) -> tuple[Path, str, str]:
     if tool is None:
         raise ValueError(f"no conversion tool for bin {args.bin!r}")  # noqa: EM102, TRY003
 
-    path_hash = hashlib.md5(str(sfinfo.filename).encode()).hexdigest()[:6]  # noqa: S324
-    wdir = sfinfo.tdir / f"{sfinfo.filename.name}_{path_hash}"
+    wdir = ws.working_dir(sfinfo.filename)
     if not wdir.exists():
         wdir.mkdir(parents=True)
 
-    target = Path(wdir / f"{sfinfo.filename.stem}.{args.target_container}")
+    target = wdir / f"{sfinfo.filename.stem}.{args.target_container}"
 
-    cmd_list = tool.build_command(sfinfo.path, args, target, wdir)
+    cmd_list = tool.build_command(ws.abs_path(sfinfo.filename), args, target, wdir)
     res = subprocess.run(cmd_list, check=False, capture_output=True, text=True)
     logtext = tool.read_log(res)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,13 @@ from pathlib import Path
 from typing import Any
 
 from fileidentification.definitions.models import SfInfo
+from fileidentification.workspace import Workspace
+
+
+def make_ws(root: str | Path = "/root", tdir: str | Path | None = None) -> Workspace:
+    """Build a Workspace for tests; tdir defaults to <root>/__fileidentification."""
+    root = Path(root)
+    return Workspace(root, Path(tdir) if tdir is not None else root / "__fileidentification")
 
 
 def fake_identify_payload(

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -95,7 +95,12 @@ class TestAddMediaInfo:
         # invariant: the converted file's filename is already its relative home, so media info must be
         # probed at the physical working-dir path passed in, never at sfinfo.filename.
         seen: list[Path] = []
-        monkeypatch.setattr(tools, "ffmpeg_media_info", lambda path: seen.append(path) or [])
+
+        def rec(path: Path) -> list[Any]:
+            seen.append(path)
+            return []
+
+        monkeypatch.setattr(tools, "ffmpeg_media_info", rec)
         s = make_sfinfo("sub/out.mp4", puid="fmt/199")  # relative home, not where the file physically is
         physical = Path("/work/out.mp4_abc123/out.mp4")
         _add_media_info(s, tool_for(Bin.FFMPEG), physical)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -17,7 +17,7 @@ from fileidentification.tasks import conversion as conv_mod
 from fileidentification.tasks.conversion import _add_media_info, _verify, convert_file
 from fileidentification.wrappers import tools
 from fileidentification.wrappers.tools import tool_for
-from tests.conftest import fake_identify_payload, make_sfinfo
+from tests.conftest import fake_identify_payload, make_sfinfo, make_ws
 
 
 def _patch_identify(monkeypatch: pytest.MonkeyPatch, target: Path, puid: str) -> None:
@@ -75,38 +75,49 @@ class TestAddMediaInfo:
     def test_ffmpeg_appends_json_streams(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(tools, "ffmpeg_media_info", lambda path: [{"codec_type": "video"}])
         s = make_sfinfo("v.mp4", puid="fmt/199")
-        _add_media_info(s, tool_for(Bin.FFMPEG))
+        _add_media_info(s, tool_for(Bin.FFMPEG), s.filename)
         assert s.media_info[0].name == "ffmpeg"
         assert '"codec_type": "video"' in s.media_info[0].msg
 
     def test_magick_appends_identify_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(tools, "imagemagick_media_info", lambda path: "TIFF 10x10")
         s = make_sfinfo("i.tif", puid="fmt/353")
-        _add_media_info(s, tool_for(Bin.MAGICK))
+        _add_media_info(s, tool_for(Bin.MAGICK), s.filename)
         assert s.media_info[0].name == "imagemagick"
         assert s.media_info[0].msg == "TIFF 10x10"
 
     def test_other_bin_is_noop(self) -> None:
         s = make_sfinfo("d.docx", puid="fmt/412")
-        _add_media_info(s, tool_for(Bin.SOFFICE))
+        _add_media_info(s, tool_for(Bin.SOFFICE), s.filename)
         assert not s.media_info
+
+    def test_probes_physical_path_not_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # invariant: the converted file's filename is already its relative home, so media info must be
+        # probed at the physical working-dir path passed in, never at sfinfo.filename.
+        seen: list[Path] = []
+        monkeypatch.setattr(tools, "ffmpeg_media_info", lambda path: seen.append(path) or [])
+        s = make_sfinfo("sub/out.mp4", puid="fmt/199")  # relative home, not where the file physically is
+        physical = Path("/work/out.mp4_abc123/out.mp4")
+        _add_media_info(s, tool_for(Bin.FFMPEG), physical)
+        assert seen == [physical]
 
 
 def test_convert_file_strips_abs_paths_from_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """convert_file removes root_folder/tdir prefixes from the tool log before attaching it."""
     origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
-    origin.root_folder = Path("/root")
-    origin.tdir = Path("/tmp/tdir")
     origin.status.pending = True
+    ws = make_ws("/root", "/tmp/tdir")
 
     target = tmp_path / "orig.tif"
     target.write_bytes(b"data")
     _patch_identify(monkeypatch, target, puid="fmt/353")
-    monkeypatch.setattr(conv_mod, "convert", lambda s, a: (target, "the cmd", "/root/sub/orig.jpg -> /tmp/tdir/out"))
-    monkeypatch.setattr(conv_mod, "_add_media_info", lambda s, b: None)
+    monkeypatch.setattr(
+        conv_mod, "convert", lambda s, a, ws: (target, "the cmd", "/root/sub/orig.jpg -> /tmp/tdir/out")
+    )
+    monkeypatch.setattr(conv_mod, "_add_media_info", lambda s, t, p: None)
 
     policies = {"fmt/43": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])}
-    result, cmds, bin_log = convert_file(origin, policies)
+    result, cmds, bin_log = convert_file(origin, policies, ws)
 
     assert result is not None
     assert cmds == ["the cmd"]
@@ -120,15 +131,14 @@ def test_convert_file_returns_bin_log_on_failure_without_touching_origin(
 ) -> None:
     """On failure the bin's log is returned (for the "errors" copy) and is not added to the origin sfinfo."""
     origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
-    origin.root_folder = Path("/root")
-    origin.tdir = Path("/tmp/tdir")
     origin.status.pending = True
+    ws = make_ws("/root", "/tmp/tdir")
 
     missing_target = tmp_path / "never-created.tif"  # never written -> conversion failed
-    monkeypatch.setattr(conv_mod, "convert", lambda s, a: (missing_target, "the cmd", "magick: some fatal error"))
+    monkeypatch.setattr(conv_mod, "convert", lambda s, a, ws: (missing_target, "the cmd", "magick: some fatal error"))
 
     policies = {"fmt/43": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])}
-    result, _, bin_log = convert_file(origin, policies)
+    result, _, bin_log = convert_file(origin, policies, ws)
 
     assert result is None
     # the failure reason is recorded on the origin, but the bin log is NOT (it only travels back to the caller)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -4,6 +4,7 @@ subprocess.run is monkeypatched so no real conversion tool is invoked; the tests
 assert on the command list / string and the returned paths.
 """
 
+import shlex
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -13,7 +14,7 @@ import pytest
 from fileidentification.definitions.models import PolicyParams, SfInfo
 from fileidentification.definitions.settings import PDFSETTINGS
 from fileidentification.wrappers import converter
-from tests.conftest import make_sfinfo
+from tests.conftest import make_sfinfo, make_ws
 
 
 @pytest.fixture
@@ -29,15 +30,13 @@ def capture_cmd(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     return calls
 
 
-def _sfinfo(tmp_path: Path) -> SfInfo:
-    s = make_sfinfo("clip.mp4", md5="abcdef0000")
-    s.tdir = tmp_path
-    s.path = tmp_path / "clip.mp4"
-    return s
+def _sfinfo(filename: str = "clip.mp4") -> SfInfo:
+    return make_sfinfo(filename, md5="abcdef0000")
 
 
 def test_ffmpeg_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo(tmp_path)
+    s = _sfinfo()
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="ffmpeg",
@@ -45,9 +44,9 @@ def test_ffmpeg_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
         processing_args="-c:v ffv1",
         expected=["fmt/569"],
     )
-    target, _cmd_str, logtext = converter.convert(s, args)
+    target, _cmd_str, logtext = converter.convert(s, args, ws)
     cmd = capture_cmd[0]
-    assert cmd[:4] == ["ffmpeg", "-y", "-i", str(s.path)]
+    assert cmd[:4] == ["ffmpeg", "-y", "-i", str(ws.abs_path(s.filename))]
     assert "-c:v" in cmd and "ffv1" in cmd  # processing_args were shlex-split
     assert cmd[-1] == str(target)
     assert target.name == "clip.mkv"
@@ -55,7 +54,8 @@ def test_ffmpeg_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
 
 
 def test_magick_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo(tmp_path)
+    s = _sfinfo()
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="magick",
@@ -63,15 +63,16 @@ def test_magick_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
         processing_args="",
         expected=["fmt/353"],
     )
-    target, _cmd_str, _logtext = converter.convert(s, args)
+    target, _cmd_str, _logtext = converter.convert(s, args, ws)
     cmd = capture_cmd[0]
     assert cmd[0] == "magick"
-    assert cmd[-2:] == [str(s.path), str(target)]
+    assert cmd[-2:] == [str(ws.abs_path(s.filename)), str(target)]
     assert target.name == "clip.tif"
 
 
 def test_soffice_pdf_uses_pdf_filter(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo(tmp_path)
+    s = _sfinfo()
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="soffice",
@@ -79,7 +80,7 @@ def test_soffice_pdf_uses_pdf_filter(capture_cmd: list[list[str]], tmp_path: Pat
         processing_args="--headless --convert-to",
         expected=["fmt/95"],
     )
-    converter.convert(s, args)
+    converter.convert(s, args, ws)
     cmd = capture_cmd[0]
     # the pdf branch wraps the container in the PDF/A export filter
     assert f"pdf{PDFSETTINGS}" in cmd
@@ -87,7 +88,8 @@ def test_soffice_pdf_uses_pdf_filter(capture_cmd: list[list[str]], tmp_path: Pat
 
 
 def test_soffice_non_pdf_uses_plain_container(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo(tmp_path)
+    s = _sfinfo()
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="soffice",
@@ -95,14 +97,13 @@ def test_soffice_non_pdf_uses_plain_container(capture_cmd: list[list[str]], tmp_
         processing_args="--headless --convert-to",
         expected=["fmt/412"],
     )
-    converter.convert(s, args)
+    converter.convert(s, args, ws)
     assert "docx" in capture_cmd[0]
 
 
 def test_cmd_str_is_shell_quoted(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = make_sfinfo("my clip.mp4", md5="abcdef0000")
-    s.tdir = tmp_path
-    s.path = tmp_path / "my clip.mp4"
+    s = _sfinfo("my clip.mp4")
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="ffmpeg",
@@ -110,23 +111,22 @@ def test_cmd_str_is_shell_quoted(capture_cmd: list[list[str]], tmp_path: Path) -
         processing_args="-c:v ffv1",
         expected=["fmt/569"],
     )
-    _target, cmd_str, _ = converter.convert(s, args)
+    _target, cmd_str, _ = converter.convert(s, args, ws)
     # a path with a space must be quoted so the string is copy-pasteable
-    import shlex
-
-    assert shlex.quote(str(s.path)) in cmd_str
+    assert shlex.quote(str(ws.abs_path(s.filename))) in cmd_str
     assert "'" in cmd_str  # the space forced shell quoting
 
 
 def test_working_dir_is_created(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo(tmp_path)
+    s = _sfinfo()
+    ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
         accepted=False,
         bin="magick",
         target_container="tif",
         expected=["fmt/353"],
     )
-    target, _, _ = converter.convert(s, args)
+    target, _, _ = converter.convert(s, args, ws)
     assert target.parent.is_dir()
     # <name>_<pathhash[:6]>: basename prefix plus a 6-char hex hash of the file's relative path
     name = target.parent.name
@@ -141,15 +141,12 @@ def test_identical_files_at_different_paths_get_distinct_working_dirs(
     # two duplicates (same content md5, same basename) at different paths must not share a working dir,
     # otherwise one conversion would overwrite the other
     args = PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
+    ws = make_ws(tmp_path, tmp_path)
 
     a = make_sfinfo("sub_a/clip.mp4", md5="abcdef0000")
-    a.tdir = tmp_path
-    a.path = tmp_path / "sub_a" / "clip.mp4"
     b = make_sfinfo("sub_b/clip.mp4", md5="abcdef0000")
-    b.tdir = tmp_path
-    b.path = tmp_path / "sub_b" / "clip.mp4"
 
-    target_a, _, _ = converter.convert(a, args)
-    target_b, _, _ = converter.convert(b, args)
+    target_a, _, _ = converter.convert(a, args, ws)
+    target_b, _, _ = converter.convert(b, args, ws)
 
     assert target_a.parent != target_b.parent

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,9 @@
-"""Unit tests for the shell-command construction in wrappers.converter.
+"""Unit tests for wrappers.converter.convert.
 
-subprocess.run is monkeypatched so no real conversion tool is invoked; the tests
-assert on the command list / string and the returned paths.
+convert() resolves the source / target / working-dir and runs the tool's command. The per-bin command
+shape is owned by test_tools (MediaTool.build_command) and the working-dir math by test_workspace, so these
+tests cover only convert()'s own wiring: source & target resolution, working-dir creation, the log stream it
+returns, and shell-quoting of the printable command. Real per-bin conversions are covered by test_docker.
 """
 
 import shlex
@@ -12,7 +14,6 @@ from typing import Any
 import pytest
 
 from fileidentification.definitions.models import PolicyParams, SfInfo
-from fileidentification.definitions.settings import PDFSETTINGS
 from fileidentification.wrappers import converter
 from tests.conftest import make_sfinfo, make_ws
 
@@ -34,119 +35,38 @@ def _sfinfo(filename: str = "clip.mp4") -> SfInfo:
     return make_sfinfo(filename, md5="abcdef0000")
 
 
-def test_ffmpeg_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
+def test_wires_source_target_and_creates_working_dir(capture_cmd: list[list[str]], tmp_path: Path) -> None:
     s = _sfinfo()
     ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
-        accepted=False,
-        bin="ffmpeg",
-        target_container="mkv",
-        processing_args="-c:v ffv1",
-        expected=["fmt/569"],
+        accepted=False, bin="ffmpeg", target_container="mkv", processing_args="-c:v ffv1", expected=["fmt/569"]
     )
     target, _cmd_str, logtext = converter.convert(s, args, ws)
     cmd = capture_cmd[0]
-    assert cmd[:4] == ["ffmpeg", "-y", "-i", str(ws.abs_path(s.filename))]
-    assert "-c:v" in cmd and "ffv1" in cmd  # processing_args were shlex-split
+    assert str(ws.abs_path(s.filename)) in cmd  # source resolved from the workspace
     assert cmd[-1] == str(target)
-    assert target.name == "clip.mkv"
-    assert logtext == "err"  # ffmpeg log comes from stderr
+    assert target.name == "clip.mkv"  # named from target_container
+    assert target.parent.is_dir()  # the working dir was created
+    assert logtext == "err"  # log comes from the tool's stream (ffmpeg: stderr)
 
 
-def test_magick_command(capture_cmd: list[list[str]], tmp_path: Path) -> None:
+def test_magick_places_source_and_target(capture_cmd: list[list[str]], tmp_path: Path) -> None:
+    # magick puts the source positionally (no -i), so guard that convert wires the other command shape too
     s = _sfinfo()
     ws = make_ws(tmp_path, tmp_path)
-    args = PolicyParams(
-        accepted=False,
-        bin="magick",
-        target_container="tif",
-        processing_args="",
-        expected=["fmt/353"],
-    )
-    target, _cmd_str, _logtext = converter.convert(s, args, ws)
-    cmd = capture_cmd[0]
-    assert cmd[0] == "magick"
-    assert cmd[-2:] == [str(ws.abs_path(s.filename)), str(target)]
+    args = PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
+    target, _, _ = converter.convert(s, args, ws)
+    assert capture_cmd[0][-2:] == [str(ws.abs_path(s.filename)), str(target)]
     assert target.name == "clip.tif"
-
-
-def test_soffice_pdf_uses_pdf_filter(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo()
-    ws = make_ws(tmp_path, tmp_path)
-    args = PolicyParams(
-        accepted=False,
-        bin="soffice",
-        target_container="pdf",
-        processing_args="--headless --convert-to",
-        expected=["fmt/95"],
-    )
-    converter.convert(s, args, ws)
-    cmd = capture_cmd[0]
-    # the pdf branch wraps the container in the PDF/A export filter
-    assert f"pdf{PDFSETTINGS}" in cmd
-    assert "--outdir" in cmd
-
-
-def test_soffice_non_pdf_uses_plain_container(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo()
-    ws = make_ws(tmp_path, tmp_path)
-    args = PolicyParams(
-        accepted=False,
-        bin="soffice",
-        target_container="docx",
-        processing_args="--headless --convert-to",
-        expected=["fmt/412"],
-    )
-    converter.convert(s, args, ws)
-    assert "docx" in capture_cmd[0]
 
 
 def test_cmd_str_is_shell_quoted(capture_cmd: list[list[str]], tmp_path: Path) -> None:
     s = _sfinfo("my clip.mp4")
     ws = make_ws(tmp_path, tmp_path)
     args = PolicyParams(
-        accepted=False,
-        bin="ffmpeg",
-        target_container="mkv",
-        processing_args="-c:v ffv1",
-        expected=["fmt/569"],
+        accepted=False, bin="ffmpeg", target_container="mkv", processing_args="-c:v ffv1", expected=["fmt/569"]
     )
     _target, cmd_str, _ = converter.convert(s, args, ws)
     # a path with a space must be quoted so the string is copy-pasteable
     assert shlex.quote(str(ws.abs_path(s.filename))) in cmd_str
     assert "'" in cmd_str  # the space forced shell quoting
-
-
-def test_working_dir_is_created(capture_cmd: list[list[str]], tmp_path: Path) -> None:
-    s = _sfinfo()
-    ws = make_ws(tmp_path, tmp_path)
-    args = PolicyParams(
-        accepted=False,
-        bin="magick",
-        target_container="tif",
-        expected=["fmt/353"],
-    )
-    target, _, _ = converter.convert(s, args, ws)
-    assert target.parent.is_dir()
-    # <name>_<pathhash[:6]>: basename prefix plus a 6-char hex hash of the file's relative path
-    name = target.parent.name
-    assert name.startswith("clip.mp4_")
-    suffix = name.rsplit("_", 1)[1]
-    assert len(suffix) == 6 and all(c in "0123456789abcdef" for c in suffix)
-
-
-def test_identical_files_at_different_paths_get_distinct_working_dirs(
-    capture_cmd: list[list[str]], tmp_path: Path
-) -> None:
-    # two duplicates (same content md5, same basename) at different paths must not share a working dir,
-    # otherwise one conversion would overwrite the other
-    args = PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
-    ws = make_ws(tmp_path, tmp_path)
-
-    a = make_sfinfo("sub_a/clip.mp4", md5="abcdef0000")
-    b = make_sfinfo("sub_b/clip.mp4", md5="abcdef0000")
-
-    target_a, _, _ = converter.convert(a, args, ws)
-    target_b, _, _ = converter.convert(b, args, ws)
-
-    assert target_a.parent != target_b.parent

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -14,7 +14,7 @@ import pytest
 from fileidentification.definitions.models import LogMsg, Policies, PolicyParams, SfInfo
 from fileidentification.definitions.settings import DEFAULTPOLICIES, FMT2EXT
 from fileidentification.filehandling import FileHandler
-from tests.conftest import fake_identify_payload, make_sfinfo
+from tests.conftest import fake_identify_payload, make_sfinfo, make_ws
 
 
 def _fake_pygfried(puid: str = "fmt/43") -> SimpleNamespace:
@@ -65,6 +65,7 @@ class TestBuildStack:
         fh = FileHandler()
         fh.fp.TMP_DIR = tmp_path / "tmp"
         fh.fp.LOGJSON = fh.fp.TMP_DIR / "_log.json"  # absent -> forces a scan
+        fh.ws = make_ws(root, fh.fp.TMP_DIR)
         monkeypatch.setattr("fileidentification.filehandling.pygfried", _fake_pygfried())
 
         fh._build_stack(root)
@@ -74,7 +75,8 @@ class TestBuildStack:
         assert {s.filename for s in fh.stack} == {Path("a.jpg"), Path("sub/b.jpg")}
         assert set(fh.ba.puid_unique) == {"fmt/43"}
         assert len(fh.ba.puid_unique["fmt/43"]) == 2
-        assert next(s for s in fh.stack if s.filename == Path("a.jpg")).path == root / "a.jpg"
+        a = next(s for s in fh.stack if s.filename == Path("a.jpg"))
+        assert fh.ws.abs_path(a.filename) == root / "a.jpg"
 
     def test_reload_from_log_skips_scan_and_removed_files(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -106,8 +108,9 @@ class TestBuildStack:
         assert len(fh.ba.puid_unique["fmt/43"]) == 1
         loaded_active = next(s for s in fh.stack if not s.status.removed)
         loaded_removed = next(s for s in fh.stack if s.status.removed)
-        assert loaded_active.path == tmp_path / "sub/a.jpg"  # paths set for active files
-        assert loaded_removed.path == Path()  # removed files are left untouched
+        # reloaded filenames are kept verbatim (already relative / portable)
+        assert loaded_active.filename == Path("sub/a.jpg")
+        assert loaded_removed.filename == Path("sub/b.jpg")
 
 
 class TestSilentlyReencode:
@@ -311,18 +314,16 @@ class TestConvert:
         fh = FileHandler()
         pending = make_sfinfo("sub/orig.jpg", puid="fmt/43")
         pending.status.pending = True
-        pending.root_folder = Path("/root")
         fh.stack = [pending]
         fh.policies = {"fmt/43": PolicyParams(format_name="JPEG", bin="magick")}
 
         converted = make_sfinfo("sub/orig.tif", puid="fmt/353")
         converted.filename = Path("sub/orig.tif")
-        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p: (converted, ["cmd"], None))
+        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p, ws: (converted, ["cmd"], None))
 
         fh.convert()
 
         assert converted in fh.stack
-        assert converted.root_folder == Path("/root")
         assert any("converted ->" in log.msg for log in pending.processing_logs)
 
     def test_soffice_conversion_is_serialized_by_the_lock(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -330,13 +331,12 @@ class TestConvert:
         fh = FileHandler()
         pending = make_sfinfo("sub/legacy.doc", puid="fmt/40")
         pending.status.pending = True
-        pending.root_folder = Path("/root")
         fh.stack = [pending]
         fh.policies = {
             "fmt/40": PolicyParams(accepted=False, bin="soffice", target_container="docx", expected=["fmt/412"])
         }
         converted = make_sfinfo("sub/legacy.docx", puid="fmt/412")
-        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p: (converted, ["cmd"], None))
+        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p, ws: (converted, ["cmd"], None))
 
         spy = _LockSpy()
         fh._soffice_lock = spy  # type: ignore[assignment]
@@ -349,13 +349,12 @@ class TestConvert:
         fh = FileHandler()
         pending = make_sfinfo("sub/orig.jpg", puid="fmt/43")
         pending.status.pending = True
-        pending.root_folder = Path("/root")
         fh.stack = [pending]
         fh.policies = {
             "fmt/43": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
         }
         converted = make_sfinfo("sub/orig.tif", puid="fmt/353")
-        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p: (converted, ["cmd"], None))
+        monkeypatch.setattr("fileidentification.filehandling.convert_file", lambda s, p, ws: (converted, ["cmd"], None))
 
         spy = _LockSpy()
         fh._soffice_lock = spy  # type: ignore[assignment]
@@ -370,7 +369,7 @@ class TestConvert:
         fh.stack = [pending]
         fh.policies = {"fmt/43": PolicyParams(format_name="JPEG", bin="magick")}
 
-        def failing_convert(sfinfo: SfInfo, policies: Policies) -> tuple[None, list[str], None]:
+        def failing_convert(sfinfo: SfInfo, policies: Policies, ws: Any) -> tuple[None, list[str], None]:
             # convert_file leaves a diagnostic on the origin before signalling failure
             sfinfo.processing_logs.append(LogMsg(name="filehandler", msg="conversion failed"))
             return None, ["thecmd"], None
@@ -395,7 +394,7 @@ class TestConvert:
         fh.stack = [origin]
         fh.policies = {"fmt/43": PolicyParams(format_name="JPEG", bin="magick")}
 
-        def failing_convert(sfinfo: SfInfo, policies: Policies) -> tuple[None, list[str], LogMsg]:
+        def failing_convert(sfinfo: SfInfo, policies: Policies, ws: Any) -> tuple[None, list[str], LogMsg]:
             sfinfo.processing_logs.append(LogMsg(name="filehandler", msg="conversion failed"))
             return None, ["thecmd"], LogMsg(name="magick", msg="magick boom detail")
 
@@ -417,10 +416,9 @@ class TestConvert:
         # end to end: the bin's log ends up only in the "errors" copy, not in "files", and is never printed
         fh = FileHandler()
         fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
         origin.status.pending = True
-        origin.root_folder = tmp_path
-        origin.tdir = tmp_path
         fh.stack = [origin]
         fh.policies = {
             "fmt/43": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
@@ -428,7 +426,7 @@ class TestConvert:
 
         missing = tmp_path / "never.tif"  # converter produces no file -> failure, with a bin log
         monkeypatch.setattr(
-            "fileidentification.tasks.conversion.convert", lambda s, a: (missing, "the cmd", "magick: boom")
+            "fileidentification.tasks.conversion.convert", lambda s, a, ws: (missing, "the cmd", "magick: boom")
         )
 
         fh.convert()
@@ -539,7 +537,7 @@ class TestTestPolicies:
         }
         seen: list[SfInfo] = []
 
-        def record(sfinfo: SfInfo, policies: Policies) -> tuple[None, list[str], None]:
+        def record(sfinfo: SfInfo, policies: Policies, ws: Any) -> tuple[None, list[str], None]:
             seen.append(sfinfo)
             return None, ["cmd"], None
 
@@ -553,7 +551,7 @@ class TestTestPolicies:
         fh.policies = {"fmt/43": PolicyParams(format_name="JPEG", accepted=True)}
         called: list[SfInfo] = []
 
-        def record(sfinfo: SfInfo, policies: Policies) -> tuple[None, list[str], None]:
+        def record(sfinfo: SfInfo, policies: Policies, ws: Any) -> tuple[None, list[str], None]:
             called.append(sfinfo)
             return None, ["cmd"], None
 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -18,7 +18,9 @@ from fileidentification.tasks import inspection as insp
 from fileidentification.tasks.inspection import _has_error, _rename, assert_file_integrity, inspect_file
 from fileidentification.wrappers import tools
 from fileidentification.wrappers.tools import tool_for
-from tests.conftest import make_sfinfo
+from tests.conftest import make_sfinfo, make_ws
+
+WS = make_ws()
 
 
 class TestInspectFileBinSelection:
@@ -28,7 +30,7 @@ class TestInspectFileBinSelection:
     def _capture_tool(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         captured: dict[str, Any] = {}
 
-        def fake_has_error(sfinfo: Any, tool: Any, log_tables: Any, verbose: bool) -> bool:
+        def fake_has_error(sfinfo: Any, tool: Any, ws: Any, log_tables: Any, verbose: bool) -> bool:
             captured["tool"] = tool
             return False
 
@@ -38,34 +40,34 @@ class TestInspectFileBinSelection:
     def test_bin_from_policy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = self._capture_tool(monkeypatch)
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg")
-        inspect_file(s, {"fmt/43": PolicyParams(format_name="x", bin="ffmpeg")}, LogTables(), verbose=False)
+        inspect_file(s, {"fmt/43": PolicyParams(format_name="x", bin="ffmpeg")}, WS, LogTables(), verbose=False)
         assert captured["tool"].bin == Bin.FFMPEG  # policy wins over the image mime
 
     def test_bin_from_siegfried_mime_image(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = self._capture_tool(monkeypatch)
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg")
-        inspect_file(s, {}, LogTables(), verbose=False)
+        inspect_file(s, {}, WS, LogTables(), verbose=False)
         assert captured["tool"].bin == Bin.MAGICK
         assert any("bin not specified" in log.msg for log in s.processing_logs)
 
     def test_bin_from_siegfried_mime_video(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = self._capture_tool(monkeypatch)
         s = make_sfinfo(puid="fmt/199", mime="video/mp4")
-        inspect_file(s, {}, LogTables(), verbose=False)
+        inspect_file(s, {}, WS, LogTables(), verbose=False)
         assert captured["tool"].bin == Bin.FFMPEG
 
     def test_bin_from_fmt2ext_when_no_siegfried_mime(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = self._capture_tool(monkeypatch)
         # empty siegfried mime forces the FMT2EXT fallback; fmt/43 is image/jpeg there
         s = make_sfinfo(puid="fmt/43", mime="")
-        inspect_file(s, {}, LogTables(), verbose=False)
+        inspect_file(s, {}, WS, LogTables(), verbose=False)
         assert captured["tool"].bin == Bin.MAGICK
 
     def test_no_bin_when_no_mime_anywhere(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured = self._capture_tool(monkeypatch)
         # fmt/569 (Matroska) has no mime key in FMT2EXT and we pass no siegfried mime
         s = make_sfinfo(puid="fmt/569", mime="")
-        inspect_file(s, {}, LogTables(), verbose=False)
+        inspect_file(s, {}, WS, LogTables(), verbose=False)
         assert captured["tool"] is None
 
 
@@ -73,7 +75,7 @@ class TestInspectFileOutcomes:
     def test_no_puid_records_processing_error(self) -> None:
         s = make_sfinfo(puid="UNKNOWN", warning="no match")  # processed_as is None
         lt = LogTables()
-        assert inspect_file(s, {}, lt, verbose=False) is None
+        assert inspect_file(s, {}, WS, lt, verbose=False) is None
         assert len(lt.processing_errors) == 1
         assert FPMsg.PUIDFAIL in lt.processing_errors[0][0].msg
 
@@ -81,14 +83,14 @@ class TestInspectFileOutcomes:
         monkeypatch.setattr(insp, "_has_error", lambda *a, **k: False)
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg")
         s.errors = FDMsg.EMPTYSOURCE
-        assert inspect_file(s, {}, LogTables(), verbose=False) is None
+        assert inspect_file(s, {}, WS, LogTables(), verbose=False) is None
         assert any(FDMsg.EMPTYSOURCE in log.msg for log in s.processing_logs)
 
     def test_extension_mismatch_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(insp, "_has_error", lambda *a, **k: False)
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg", warning=FDMsg.EXTMISMATCH)
         lt = LogTables()
-        assert inspect_file(s, {}, lt, verbose=False) == FDMsg.EXTMISMATCH
+        assert inspect_file(s, {}, WS, lt, verbose=False) == FDMsg.EXTMISMATCH
         assert FDMsg.EXTMISMATCH.name in lt.diagnostics
         assert any("expecting one of the following ext" in log.msg for log in s.processing_logs)
 
@@ -96,7 +98,7 @@ class TestInspectFileOutcomes:
         monkeypatch.setattr(insp, "_has_error", lambda *a, **k: True)
         # even with an ext-mismatch warning, a corrupt file returns ERROR first
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg", warning=FDMsg.EXTMISMATCH)
-        assert inspect_file(s, {}, LogTables(), verbose=False) == FDMsg.ERROR
+        assert inspect_file(s, {}, WS, LogTables(), verbose=False) == FDMsg.ERROR
 
 
 class TestHasError:
@@ -111,7 +113,7 @@ class TestHasError:
     def test_ffmpeg_reencode_flag_sets_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_ffmpeg(monkeypatch, (False, str(REencMsg.ffmpeg1), ""))
         s = make_sfinfo("v.mp4", puid="fmt/199")
-        assert _has_error(s, tool_for(Bin.FFMPEG), LogTables(), verbose=False) is False
+        assert _has_error(s, tool_for(Bin.FFMPEG), WS, LogTables(), verbose=False) is False
         assert s.status.pending is True
         assert any("reencoding" in log.msg for log in s.processing_logs)
 
@@ -119,7 +121,7 @@ class TestHasError:
         self._patch_ffmpeg(monkeypatch, (True, "boom", "specs"))
         s = make_sfinfo("v.mp4", puid="fmt/199")
         lt = LogTables()
-        assert _has_error(s, tool_for(Bin.FFMPEG), lt, verbose=False) is True
+        assert _has_error(s, tool_for(Bin.FFMPEG), WS, lt, verbose=False) is True
         assert s.media_info and s.media_info[0].msg == "specs"
         assert s.warnings and s.warnings[0].msg == "boom"
         assert FDMsg.ERROR.name in lt.diagnostics
@@ -128,7 +130,7 @@ class TestHasError:
         self._patch_ffmpeg(monkeypatch, (False, "just a warning", ""))
         s = make_sfinfo("v.mp4", puid="fmt/199")
         lt = LogTables()
-        assert _has_error(s, tool_for(Bin.FFMPEG), lt, verbose=False) is False
+        assert _has_error(s, tool_for(Bin.FFMPEG), WS, lt, verbose=False) is False
         assert s.warnings and s.warnings[0].msg == "just a warning"
         assert FDMsg.WARNING.name in lt.diagnostics
         assert s.status.pending is False
@@ -136,12 +138,12 @@ class TestHasError:
     def test_magick_error_is_corrupt(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_magick(monkeypatch, (True, "identify: Cannot read", "specs"))
         s = make_sfinfo("i.jpg", puid="fmt/43")
-        assert _has_error(s, tool_for(Bin.MAGICK), LogTables(), verbose=False) is True
+        assert _has_error(s, tool_for(Bin.MAGICK), WS, LogTables(), verbose=False) is True
 
     def test_soffice_and_empty_bin_are_noops(self) -> None:
         s = make_sfinfo("d.docx", puid="fmt/412")
-        assert _has_error(s, tool_for(Bin.SOFFICE), LogTables(), verbose=False) is False
-        assert _has_error(s, tool_for(""), LogTables(), verbose=False) is False
+        assert _has_error(s, tool_for(Bin.SOFFICE), WS, LogTables(), verbose=False) is False
+        assert _has_error(s, tool_for(""), WS, LogTables(), verbose=False) is False
         assert not s.warnings and not s.media_info
 
     def test_specs_not_overwritten_when_media_info_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -150,42 +152,39 @@ class TestHasError:
         self._patch_ffmpeg(monkeypatch, (False, "", "new-specs"))
         s = make_sfinfo("v.mp4", puid="fmt/199")
         s.media_info.append(LogMsg(name="ffmpeg", msg="pre-existing"))
-        _has_error(s, tool_for(Bin.FFMPEG), LogTables(), verbose=False)
+        _has_error(s, tool_for(Bin.FFMPEG), WS, LogTables(), verbose=False)
         assert len(s.media_info) == 1  # existing media_info left untouched
 
 
 class TestRename:
-    def _staged(self, tmp_path: Path, name: str = "clip") -> Any:
+    def _staged(self, tmp_path: Path, name: str = "clip") -> tuple[Any, Any]:
         root = tmp_path / "root"
         (root / "sub").mkdir(parents=True)
-        f = root / "sub" / name
-        f.write_bytes(b"data")
+        (root / "sub" / name).write_bytes(b"data")
         s = make_sfinfo(f"sub/{name}", md5="abcdef0000")
-        s.path = f
-        s.root_folder = root
-        return s
+        return s, make_ws(root, tmp_path / "tdir")
 
     def test_renames_to_extension(self, tmp_path: Path) -> None:
-        s = self._staged(tmp_path)
-        _rename(s, ".avi", LogTables())
+        s, ws = self._staged(tmp_path)
+        _rename(s, ".avi", ws, LogTables())
         assert (tmp_path / "root" / "sub" / "clip.avi").is_file()
-        assert s.path == tmp_path / "root" / "sub" / "clip.avi"
         assert s.filename == Path("sub/clip.avi")
+        assert ws.abs_path(s.filename) == tmp_path / "root" / "sub" / "clip.avi"
         assert any("did rename" in log.msg for log in s.processing_logs)
 
     def test_collision_appends_md5(self, tmp_path: Path) -> None:
-        s = self._staged(tmp_path)
+        s, ws = self._staged(tmp_path)
         (tmp_path / "root" / "sub" / "clip.avi").write_bytes(b"pre-existing")  # occupy the target name
-        _rename(s, ".avi", LogTables())
+        _rename(s, ".avi", ws, LogTables())
         assert (tmp_path / "root" / "sub" / "clip_abcdef.avi").is_file()
         assert (tmp_path / "root" / "sub" / "clip.avi").read_bytes() == b"pre-existing"
+        assert s.filename == Path("sub/clip_abcdef.avi")
 
     def test_oserror_is_recorded(self, tmp_path: Path) -> None:
-        s = make_sfinfo("sub/gone", md5="abcdef0000")
-        s.path = tmp_path / "gone"  # never created -> rename raises
-        s.root_folder = tmp_path
+        s = make_sfinfo("sub/gone", md5="abcdef0000")  # abs_path resolves under root but was never created
+        ws = make_ws(tmp_path, tmp_path / "tdir")
         lt = LogTables()
-        _rename(s, ".avi", lt)
+        _rename(s, ".avi", ws, lt)
         assert lt.processing_errors
         assert not any("did rename" in log.msg for log in s.processing_logs)
 
@@ -197,21 +196,21 @@ class TestAssertFileIntegrity:
     def _spy(monkeypatch: pytest.MonkeyPatch, verdict: FDMsg | None) -> dict[str, Any]:
         calls: dict[str, Any] = {"removed": [], "renamed": []}
         monkeypatch.setattr(insp, "inspect_file", lambda *a, **k: verdict)
-        monkeypatch.setattr(insp, "remove", lambda sfinfo, lt: calls["removed"].append(sfinfo))
-        monkeypatch.setattr(insp, "_rename", lambda sfinfo, ext, lt: calls["renamed"].append(ext))
+        monkeypatch.setattr(insp, "remove", lambda sfinfo, ws, lt: calls["removed"].append(sfinfo))
+        monkeypatch.setattr(insp, "_rename", lambda sfinfo, ext, ws, lt: calls["renamed"].append(ext))
         return calls
 
     def test_corrupt_is_removed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls = self._spy(monkeypatch, FDMsg.ERROR)
         s = make_sfinfo(puid="fmt/43")
-        assert_file_integrity(s, {}, LogTables(), verbose=False)
+        assert_file_integrity(s, {}, WS, LogTables(), verbose=False)
         assert calls["removed"] == [s]
         assert not calls["renamed"]
 
     def test_single_extension_is_autorenamed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls = self._spy(monkeypatch, FDMsg.EXTMISMATCH)
         s = make_sfinfo(puid="fmt/5")  # AVI: exactly one known extension
-        assert_file_integrity(s, {}, LogTables(), verbose=False)
+        assert_file_integrity(s, {}, WS, LogTables(), verbose=False)
         assert calls["renamed"] == [".avi"]
         assert not calls["removed"]
 
@@ -221,12 +220,12 @@ class TestAssertFileIntegrity:
         calls = self._spy(monkeypatch, FDMsg.EXTMISMATCH)
         s = make_sfinfo(puid="fmt/43")  # JPEG: several known extensions
         s.processing_logs.append(LogMsg(name="filehandler", msg="expecting one of ..."))
-        assert_file_integrity(s, {}, LogTables(), verbose=False)
+        assert_file_integrity(s, {}, WS, LogTables(), verbose=False)
         assert not calls["renamed"]
         assert not calls["removed"]
 
     def test_clean_file_is_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls = self._spy(monkeypatch, None)
         s = make_sfinfo(puid="fmt/43")
-        assert_file_integrity(s, {}, LogTables(), verbose=False)
+        assert_file_integrity(s, {}, WS, LogTables(), verbose=False)
         assert not calls["removed"] and not calls["renamed"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -89,34 +89,6 @@ class TestSfInfoModelPostInit:
         assert not s.status.pending
 
 
-class TestSetProcessingPaths:
-    def test_initial_makes_filename_relative(self) -> None:
-        s = make_sfinfo(filename="/root/sub/x.jpg")
-        s.set_processing_paths(Path("/root"), Path("/tmp/tdir"), initial=True)
-        assert s.filename == Path("sub/x.jpg")
-        assert s.path == Path("/root/sub/x.jpg")
-        assert s.root_folder == Path("/root")
-
-    def test_non_initial_keeps_filename(self) -> None:
-        s = make_sfinfo(filename="sub/x.jpg")
-        s.set_processing_paths(Path("/root"), Path("/tmp/tdir"), initial=False)
-        assert s.filename == Path("sub/x.jpg")
-        assert s.path == Path("/root/sub/x.jpg")
-
-    def test_file_root_uses_parent(self, tmp_path: Path) -> None:
-        root_file = tmp_path / "only.jpg"
-        root_file.write_bytes(b"x")
-        s = make_sfinfo(filename=str(root_file))
-        s.set_processing_paths(root_file, tmp_path / "tdir", initial=True)
-        assert s.root_folder == tmp_path
-
-    def test_dest_skips_path_assignment(self) -> None:
-        s = make_sfinfo(filename="sub/x.jpg")
-        s.dest = Path("out")
-        s.set_processing_paths(Path("/root"), Path("/tmp/tdir"), initial=False)
-        assert s.path == Path()  # untouched default
-
-
 class TestLogTables:
     def test_diagnostics_add_groups_by_message(self) -> None:
         lt = LogTables()

--- a/tests/test_os_tasks.py
+++ b/tests/test_os_tasks.py
@@ -7,7 +7,8 @@ import pytest
 from fileidentification.definitions.models import FilePaths, LogTables, PolicyParams, SfInfo
 from fileidentification.definitions.settings import LOGJSON, POLJSON, RMV_DIR, TMP_DIR
 from fileidentification.tasks.os_tasks import move_tmp, remove, set_filepaths
-from tests.conftest import make_sfinfo
+from fileidentification.workspace import Workspace
+from tests.conftest import make_sfinfo, make_ws
 
 
 class TestSetFilepaths:
@@ -49,25 +50,21 @@ class TestRemove:
         root.mkdir()
         f = root / "bad.mp4"
         f.write_bytes(b"data")
+        ws = make_ws(root, tmp_path / "tdir")
         s = make_sfinfo("bad.mp4")
-        s.path = f
-        s.filename = Path("bad.mp4")
-        s.tdir = tmp_path / "tdir"
 
-        remove(s, LogTables())
+        remove(s, ws, LogTables())
 
         assert s.status.removed
         assert not f.exists()
-        assert (s.tdir / RMV_DIR / "bad.mp4").is_file()
+        assert (ws.tdir / RMV_DIR / "bad.mp4").is_file()
 
     def test_missing_source_records_processing_error(self, tmp_path: Path) -> None:
-        s = make_sfinfo("gone.mp4")
-        s.path = tmp_path / "gone.mp4"  # never created
-        s.filename = Path("gone.mp4")
-        s.tdir = tmp_path / "tdir"
+        ws = make_ws(tmp_path / "root", tmp_path / "tdir")
+        s = make_sfinfo("gone.mp4")  # abs_path resolves under root but the file was never created
         lt = LogTables()
 
-        remove(s, lt)
+        remove(s, ws, lt)
 
         assert not s.status.removed
         assert lt.processing_errors  # the OSError was captured
@@ -79,34 +76,32 @@ class TestMoveTmp:
     @staticmethod
     def _scenario(
         tmp_path: Path, *, conv_md5: str = "bbbbbb", remove_in_policy: bool = False
-    ) -> tuple[list[SfInfo], SfInfo, SfInfo, dict[str, PolicyParams], Path]:
+    ) -> tuple[list[SfInfo], SfInfo, SfInfo, dict[str, PolicyParams], Path, Workspace]:
         """Lay out a realistic post-conversion state on disk.
 
-        root/sub/orig.jpg          original file
-        work/orig.jpg_xxxxxx/orig.tif   converted file (to be moved)
+        root/sub/orig.jpg                             original file
+        tdir/orig.jpg_<hash>/orig.tif                 converted file, in its working dir (to be moved)
 
-        Returns (stack, original, converted, policies, root).
+        The converted SfInfo's filename is already its relative home (sub/orig.tif); the physical file
+        lives at ws.working_file(original.filename, "orig.tif"). Returns (stack, original, converted,
+        policies, root, ws).
         """
         root = tmp_path / "root"
         (root / "sub").mkdir(parents=True)
-        orig_path = root / "sub" / "orig.jpg"
-        orig_path.write_bytes(b"original")
+        (root / "sub" / "orig.jpg").write_bytes(b"original")
 
-        workdir = tmp_path / "work" / "orig.jpg_xxxxxx"
-        workdir.mkdir(parents=True)
-        conv_path = workdir / "orig.tif"
-        conv_path.write_bytes(b"converted")
+        ws = make_ws(root, tmp_path / "tdir")
 
         original = make_sfinfo("sub/orig.jpg", puid="fmt/43", md5="aaaaaa")
-        original.path = orig_path
-        original.root_folder = root
-        original.tdir = tmp_path / "tdir"
 
-        converted = make_sfinfo(conv_path, puid="fmt/353", md5=conv_md5, mime="image/tiff")
-        converted.filename = conv_path  # source path for the move
+        converted = make_sfinfo("sub/orig.tif", puid="fmt/353", md5=conv_md5, mime="image/tiff")
         converted.dest = Path("sub")
         converted.derived_from = original
-        converted.root_folder = root
+
+        # place the physical converted file where move_tmp will look for it
+        workfile = ws.working_file(original.filename, "orig.tif")
+        workfile.parent.mkdir(parents=True)
+        workfile.write_bytes(b"converted")
 
         policies = {
             "fmt/43": PolicyParams(
@@ -117,13 +112,13 @@ class TestMoveTmp:
                 remove_original=remove_in_policy,
             )
         }
-        return [original, converted], original, converted, policies, root
+        return [original, converted], original, converted, policies, root, ws
 
     def test_moves_converted_file_next_to_original(self, tmp_path: Path) -> None:
-        stack, original, converted, policies, root = self._scenario(tmp_path)
-        workdir = converted.filename.parent
+        stack, original, converted, policies, root, ws = self._scenario(tmp_path)
+        workdir = ws.working_file(original.filename, "orig.tif").parent
 
-        moved = move_tmp(stack, policies, LogTables(), remove_original=False)
+        moved = move_tmp(stack, ws, policies, LogTables(), remove_original=False)
 
         assert moved is True
         assert (root / "sub" / "orig.tif").is_file()
@@ -131,44 +126,44 @@ class TestMoveTmp:
         assert converted.status.added is True
         assert converted.dest is None
         assert converted.filename == Path("sub/orig.tif")
-        assert original.path.is_file()  # original kept (no remove flag)
+        assert ws.abs_path(original.filename).is_file()  # original kept (no remove flag)
 
     def test_filename_collision_appends_md5(self, tmp_path: Path) -> None:
-        stack, _original, converted, policies, root = self._scenario(tmp_path, conv_md5="abc123def")
+        stack, _original, converted, policies, root, ws = self._scenario(tmp_path, conv_md5="abc123def")
         # a file already sits at the destination name
         existing = root / "sub" / "orig.tif"
         existing.write_bytes(b"pre-existing")
 
-        move_tmp(stack, policies, LogTables(), remove_original=False)
+        move_tmp(stack, ws, policies, LogTables(), remove_original=False)
 
         assert existing.read_bytes() == b"pre-existing"  # untouched
         assert (root / "sub" / "orig_abc123.tif").is_file()  # md5[:6] suffix
         assert converted.filename == Path("sub/orig_abc123.tif")
 
     def test_remove_original_flag_quarantines_source(self, tmp_path: Path) -> None:
-        stack, original, _converted, policies, root = self._scenario(tmp_path)
+        stack, original, _converted, policies, root, ws = self._scenario(tmp_path)
 
-        move_tmp(stack, policies, LogTables(), remove_original=True)
+        move_tmp(stack, ws, policies, LogTables(), remove_original=True)
 
         assert original.status.removed is True
-        assert not original.path.exists()
-        assert (original.tdir / RMV_DIR / "sub" / "orig.jpg").is_file()
+        assert not ws.abs_path(original.filename).exists()
+        assert (ws.tdir / RMV_DIR / "sub" / "orig.jpg").is_file()
         assert (root / "sub" / "orig.tif").is_file()  # conversion still placed
 
     def test_policy_remove_original_quarantines_even_without_flag(self, tmp_path: Path) -> None:
-        stack, original, _converted, policies, _root = self._scenario(tmp_path, remove_in_policy=True)
+        stack, original, _converted, policies, _root, ws = self._scenario(tmp_path, remove_in_policy=True)
 
-        move_tmp(stack, policies, LogTables(), remove_original=False)
+        move_tmp(stack, ws, policies, LogTables(), remove_original=False)
 
         assert original.status.removed is True
-        assert not original.path.exists()
+        assert not ws.abs_path(original.filename).exists()
 
     def test_nothing_to_move_returns_false(self) -> None:
         plain = make_sfinfo("a.jpg")  # no dest -> not a converted file
-        assert move_tmp([plain], {}, LogTables(), remove_original=False) is False
+        assert move_tmp([plain], make_ws(), {}, LogTables(), remove_original=False) is False
 
     def test_move_failure_records_processing_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        stack, _original, converted, policies, _root = self._scenario(tmp_path)
+        stack, _original, converted, policies, _root, ws = self._scenario(tmp_path)
 
         def boom(*_a: object, **_k: object) -> None:
             raise OSError
@@ -176,7 +171,7 @@ class TestMoveTmp:
         monkeypatch.setattr("fileidentification.tasks.os_tasks.shutil.move", boom)
         lt = LogTables()
 
-        move_tmp(stack, policies, lt, remove_original=False)
+        move_tmp(stack, ws, policies, lt, remove_original=False)
 
         assert lt.processing_errors  # the OSError was captured
         assert not converted.status.added  # move did not complete

--- a/tests/test_os_tasks.py
+++ b/tests/test_os_tasks.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from fileidentification.definitions.models import FilePaths, LogTables, PolicyParams, SfInfo
+from fileidentification.definitions.models import LogTables, PolicyParams, SfInfo
 from fileidentification.definitions.settings import LOGJSON, POLJSON, RMV_DIR, TMP_DIR
 from fileidentification.tasks.os_tasks import move_tmp, remove, set_filepaths
-from fileidentification.workspace import Workspace
+from fileidentification.workspace import FilePaths, Workspace
 from tests.conftest import make_sfinfo, make_ws
 
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -15,7 +15,7 @@ from fileidentification.definitions.models import LogTables, Mode, PolicyParams
 from fileidentification.definitions.settings import DEFAULTPOLICIES, FMT2EXT, PLMsg
 from fileidentification.tasks import policies as policies_mod
 from fileidentification.tasks.policies import apply_policy, build_policies
-from tests.conftest import make_sfinfo
+from tests.conftest import make_sfinfo, make_ws
 
 
 def _unknown_puid() -> str:
@@ -26,45 +26,46 @@ def _unknown_puid() -> str:
 
 ACCEPTED = PolicyParams(format_name="JPEG", accepted=True)
 CONVERT = PolicyParams(format_name="JPEG", accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])
+WS = make_ws()
 
 
 def test_no_puid_is_noop() -> None:
     s = make_sfinfo(puid="UNKNOWN", warning="no match")  # processed_as is None
-    apply_policy(s, {}, LogTables(), strict=False)
+    apply_policy(s, {}, WS, LogTables(), strict=False)
     assert not s.status.pending
 
 
 def test_already_pending_is_noop() -> None:
     s = make_sfinfo()
     s.status.pending = True
-    apply_policy(s, {"fmt/43": CONVERT}, LogTables(), strict=False)
+    apply_policy(s, {"fmt/43": CONVERT}, WS, LogTables(), strict=False)
     assert s.status.pending  # unchanged, no error
 
 
 def test_accepted_file_stays() -> None:
     s = make_sfinfo()
-    apply_policy(s, {"fmt/43": ACCEPTED}, LogTables(), strict=False)
+    apply_policy(s, {"fmt/43": ACCEPTED}, WS, LogTables(), strict=False)
     assert not s.status.pending
 
 
 def test_not_accepted_marks_pending() -> None:
     s = make_sfinfo()
-    apply_policy(s, {"fmt/43": CONVERT}, LogTables(), strict=False)
+    apply_policy(s, {"fmt/43": CONVERT}, WS, LogTables(), strict=False)
     assert s.status.pending
 
 
 def test_missing_policy_non_strict_is_skipped() -> None:
     s = make_sfinfo()
-    apply_policy(s, {}, LogTables(), strict=False)
+    apply_policy(s, {}, WS, LogTables(), strict=False)
     assert not s.status.pending
     assert any(PLMsg.SKIPPED in log.msg for log in s.processing_logs)
 
 
 def test_missing_policy_strict_calls_remove(monkeypatch: pytest.MonkeyPatch) -> None:
     removed: list[Any] = []
-    monkeypatch.setattr(policies_mod, "remove", lambda sfinfo, lt: removed.append(sfinfo))
+    monkeypatch.setattr(policies_mod, "remove", lambda sfinfo, ws, lt: removed.append(sfinfo))
     s = make_sfinfo()
-    apply_policy(s, {}, LogTables(), strict=True)
+    apply_policy(s, {}, WS, LogTables(), strict=True)
     assert removed == [s]
     assert any(PLMsg.NOTINPOLICIES in log.msg for log in s.processing_logs)
 
@@ -81,7 +82,7 @@ class TestInvalidStreams:
             [{"codec_type": "video", "codec_name": "h264"}, {"codec_type": "audio", "codec_name": "aac"}],
         )
         s = make_sfinfo("v.mp4", puid="fmt/199", mime="video/mp4")
-        apply_policy(s, {"fmt/199": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/199": ACCEPTED}, WS, LogTables(), strict=False)
         assert not s.status.pending
 
     def test_mp4_with_wrong_codec_is_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -90,25 +91,25 @@ class TestInvalidStreams:
             [{"codec_type": "video", "codec_name": "hevc"}, {"codec_type": "audio", "codec_name": "aac"}],
         )
         s = make_sfinfo("v.mp4", puid="fmt/199", mime="video/mp4")
-        apply_policy(s, {"fmt/199": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/199": ACCEPTED}, WS, LogTables(), strict=False)
         assert s.status.pending
 
     def test_mkv_with_ffv1_not_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_streams(monkeypatch, [{"codec_type": "video", "codec_name": "ffv1"}])
         s = make_sfinfo("v.mkv", puid="fmt/569", mime="video/x-matroska")
-        apply_policy(s, {"fmt/569": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/569": ACCEPTED}, WS, LogTables(), strict=False)
         assert not s.status.pending
 
     def test_mkv_without_ffv1_is_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_streams(monkeypatch, [{"codec_type": "video", "codec_name": "h264"}])
         s = make_sfinfo("v.mkv", puid="fmt/569", mime="video/x-matroska")
-        apply_policy(s, {"fmt/569": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/569": ACCEPTED}, WS, LogTables(), strict=False)
         assert s.status.pending
 
     def test_unprobeable_av_file_is_not_pending(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._patch_streams(monkeypatch, None)
         s = make_sfinfo("v.mp4", puid="fmt/199", mime="video/mp4")
-        apply_policy(s, {"fmt/199": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/199": ACCEPTED}, WS, LogTables(), strict=False)
         assert not s.status.pending
 
     def test_mp4_ignores_non_av_streams(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -122,7 +123,7 @@ class TestInvalidStreams:
             ],
         )
         s = make_sfinfo("v.mp4", puid="fmt/199", mime="video/mp4")
-        apply_policy(s, {"fmt/199": ACCEPTED}, LogTables(), strict=False)
+        apply_policy(s, {"fmt/199": ACCEPTED}, WS, LogTables(), strict=False)
         assert not s.status.pending
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,83 @@
+"""Unit tests for the Workspace path calculator.
+
+Pure path arithmetic — no disk is touched except the single-file-target case (which needs a real file
+so `is_file()` fires) and nothing shells out. Covers the portability, cross-volume tmp, and
+duplicate-basename cases the refactor depends on.
+"""
+
+from pathlib import Path
+
+from fileidentification.workspace import Workspace
+
+
+def _ws(root: str = "/data/root", tdir: str = "/data/root/__fileidentification") -> Workspace:
+    return Workspace(Path(root), Path(tdir))
+
+
+class TestRelativize:
+    def test_makes_scanned_path_relative_to_root(self) -> None:
+        assert _ws().relativize(Path("/data/root/sub/a.jpg")) == Path("sub/a.jpg")
+
+    def test_top_level_file(self) -> None:
+        assert _ws().relativize(Path("/data/root/a.jpg")) == Path("a.jpg")
+
+
+class TestAbsPath:
+    def test_joins_root_and_relative(self) -> None:
+        assert _ws().abs_path(Path("sub/a.jpg")) == Path("/data/root/sub/a.jpg")
+
+    def test_roundtrips_with_relativize(self) -> None:
+        ws = _ws()
+        abs_p = Path("/data/root/sub/a.jpg")
+        assert ws.abs_path(ws.relativize(abs_p)) == abs_p
+
+
+class TestWorkingDir:
+    def test_under_tdir_with_hashed_basename(self) -> None:
+        wd = _ws().working_dir(Path("sub/a.jpg"))
+        assert wd.parent == Path("/data/root/__fileidentification")
+        assert wd.name.startswith("a.jpg_")
+        suffix = wd.name.rsplit("_", 1)[1]
+        assert len(suffix) == 6 and all(c in "0123456789abcdef" for c in suffix)
+
+    def test_duplicate_basename_different_path_gets_distinct_dirs(self) -> None:
+        ws = _ws()
+        assert ws.working_dir(Path("a/clip.mp4")) != ws.working_dir(Path("b/clip.mp4"))
+
+    def test_is_deterministic(self) -> None:
+        ws = _ws()
+        assert ws.working_dir(Path("sub/a.jpg")) == ws.working_dir(Path("sub/a.jpg"))
+
+
+class TestWorkingFile:
+    def test_inside_origin_working_dir(self) -> None:
+        ws = _ws()
+        origin = Path("sub/orig.jpg")
+        assert ws.working_file(origin, "orig.tif") == ws.working_dir(origin) / "orig.tif"
+
+
+class TestRemovedDest:
+    def test_under_removed_preserving_subpath(self) -> None:
+        assert _ws().removed_dest(Path("sub/a.jpg")) == Path("/data/root/__fileidentification/_REMOVED/sub/a.jpg")
+
+
+class TestCrossVolumeTdir:
+    def test_tdir_outside_root_is_independent(self) -> None:
+        # --tmp-dir on a different volume: abs paths resolve under root, working paths under tdir
+        ws = Workspace(Path("/data/root"), Path("/mnt/external/tmp"))
+        assert ws.abs_path(Path("sub/a.jpg")) == Path("/data/root/sub/a.jpg")
+        assert ws.working_dir(Path("sub/a.jpg")).parent == Path("/mnt/external/tmp")
+        assert ws.removed_dest(Path("a.jpg")) == Path("/mnt/external/tmp/_REMOVED/a.jpg")
+
+
+class TestSingleFileTarget:
+    def test_root_folder_normalized_to_parent(self, tmp_path: Path) -> None:
+        f = tmp_path / "solo.jpg"
+        f.write_bytes(b"x")
+        ws = Workspace(f, tmp_path / "tmp")
+        assert ws.root_folder == tmp_path
+        assert ws.abs_path(Path("solo.jpg")) == tmp_path / "solo.jpg"
+
+    def test_directory_target_is_left_as_is(self, tmp_path: Path) -> None:
+        ws = Workspace(tmp_path, tmp_path / "tmp")
+        assert ws.root_folder == tmp_path


### PR DESCRIPTION
Gives "where is this file physically, and where does it go" a single owner. Path resolution was re-derived inline across `SfInfo`, `converter`, `os_tasks` and `inspection`, and depended on hand-syncing the relative `filename` with an absolute `path` — the source of the earlier path bugs (#103, #77). No behaviour change.

## What changed

**`Workspace` — a per-run path calculator** (`fileidentification/workspace.py`)
Constructed fresh each run from `(root_folder, tmp_dir)`, never persisted. Owns `abs_path`, `working_dir` (incl. the md5-of-relative-path hash), `working_file`, `removed_dest`, and `relativize`. Pure, no `SfInfo` dependency, unit-tested in isolation.

**`SfInfo` slimmed** — dropped the transient `path`, `root_folder`, `tdir` fields and `set_processing_paths`. It is now data + processing state only. The `filename`/`path` drift is gone: the relative `filename` is the single source of truth, the absolute path is always `ws.abs_path(filename)`.

**Converted files normalized immediately** — a converted file's `filename` is its relative home from birth; the physical working-dir location is derived via `ws.working_file`. This also fixes a latent bug where a converted-but-unmoved file could persist an absolute `filename` into `_log.json`.

**`FilePaths` co-located** with `Workspace` (both are run-scoped path types; `FilePaths.TMP_DIR == Workspace.tdir`).

Disk-touching tasks (`convert`, `convert_file`, `remove`, `move_tmp`, `inspect_file`, `_has_error`, `_rename`, `apply_policy`) now receive the `Workspace`.

## Why it's safe
- Portability preserved: only freshly-scanned filenames are relativized; reloaded ones are used verbatim. Added an `initial = not self.stack` guard so an empty-`files` reload can't leak absolute paths.
- Cross-volume `--tmp-dir` preserved (moves still use `shutil.move`); covered by an explicit `test_workspace` case.
- Reading/validating an existing policies file still exits on error (untouched).

## Verification
- **180 unit tests** + **12 docker end-to-end tests** pass; ruff + mypy (strict, 33 files) clean.
- New: `test_workspace.py`; invariant tests for the `move_tmp` collision rewrite and media-info probing the physical path.
- Trimmed `test_converter` down to `convert()`'s own wiring — per-bin command shape is now owned by `test_tools`, working-dir math by `test_workspace`, real conversions by `test_docker`.

No version bump (left for the release PR, consistent with prior work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)