### PR TITLE
refactor: fold FilePaths into Workspace, drop log_target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ just dasch          # DaSCH-specific: use dasch_policies.json as default, then d
 ### Data Flow
 
 1. `identify.py` — Typer CLI entrypoint; collects all flags and delegates to `FileHandler.run()`
-2. `FileHandler` (`fileidentification/filehandling.py`) — main orchestrator class; holds the processing state (`stack`, `policies`, `ba`, `log_tables`, `fp`, `mode`)
+2. `FileHandler` (`fileidentification/filehandling.py`) — main orchestrator class; holds the processing state (`stack`, `policies`, `ba`, `log_tables`, `ws`, `mode`)
 3. `_build_stack` populates `self.stack` — either reloading an existing `_log.json` or scanning the folder with pygfried; each file becomes an `SfInfo` object
 4. `_resolve_policies` sets `self.policies` (JSON keyed by PUID) — read from an existing file (`_read_policies`) or generated (`_gen_policies`)
 5. Tasks (integrity check, apply policies, convert, move) operate on the stack in sequence
@@ -64,7 +64,7 @@ just dasch          # DaSCH-specific: use dasch_policies.json as default, then d
 - **`BasicAnalytics`** — groups `SfInfo` objects by PUID and tracks duplicates (by MD5)
 - **`LogTables`** — accumulates diagnostics and processing errors during a run. Thread-safe: `diagnostics_add` and `processing_error_add` both hold an internal `threading.Lock`.
 - **`Mode`** — flags: `REMOVEORIGINAL`, `VERBOSE`, `STRICT`, `QUIET`
-- **`FilePaths`** — resolved paths for `TMP_DIR`, `POLJSON` (`_policies.json`), `LOGJSON` (`_log.json`)
+- **`Workspace`** (`fileidentification/workspace.py`) — the single run-scoped path module; a frozen dataclass holding `root_folder` + `tmp_dir`, built once via `Workspace.for_run(root, tmp_dir)` (validates root, normalizes a single-file target, creates the tmp dir). Derives `logjson` (`_log.json`), `poljson` (`_policies.json`), and `report_json(ymd)`, plus `abs_path` / `working_dir` / `removed_dest`. `write_logs` targets `ws.logjson` by default; the read-only `inspect` mode passes `ws.report_json(ymd)` so its report stays separate from a processing run.
 
 ### Task Modules (`fileidentification/tasks/`)
 
@@ -73,7 +73,7 @@ just dasch          # DaSCH-specific: use dasch_policies.json as default, then d
 | `inspection.py` | `inspect_file` / `assert_file_integrity` — probes files via ffmpeg/magick, detects corruption and extension mismatches |
 | `policies.py` | `apply_policy` — marks `SfInfo.status.pending = True` for files that need conversion |
 | `conversion.py` | `convert_file` — runs the converter, then re-identifies output with pygfried to verify |
-| `os_tasks.py` | `move_tmp`, `set_filepaths` — filesystem operations, moving converted files to destination |
+| `os_tasks.py` | `move_tmp`, `remove` — filesystem operations, moving converted files to destination and quarantining removed ones |
 | `console_output.py` | Rich/typer formatted console output (tables, diagnostics) |
 
 ### Wrappers (`fileidentification/wrappers/`)
@@ -103,8 +103,9 @@ Contains alternative policy sets (e.g. `dasch_policies.json`). `just setdasch` c
 
 ### Temporary Files
 
-During processing, `__fileidentification/` is created inside the target directory (or a custom `--tmp-dir`):
+`Workspace.for_run` creates the tmp dir: `__fileidentification/` inside the target directory, `<parent>/<stem>/` for a single-file target, or a custom `--tmp-dir` (which may be on another volume). It holds:
 - `_policies.json` — generated or read-in policies
 - `_log.json` — cumulative log of all processing (appended across runs)
+- `<yymmdd>_report.json` — written by the read-only `--inspect` mode instead of `_log.json`
 - `_REMOVED/` — corrupt or removed files
 - `<filename>_<pathhash[:6]>/` — per-file conversion working directories with converted file

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pygfried
 from rich.progress import Progress, SpinnerColumn, TextColumn
-from typer import colors, secho
+from typer import Exit, colors, secho
 
 from fileidentification.definitions.models import (
     BasicAnalytics,
@@ -31,13 +31,14 @@ from fileidentification.tasks.console_output import (
     print_fmts,
     print_msg,
     print_processing_errors,
+    print_root_not_found,
     print_siegfried_errors,
 )
 from fileidentification.tasks.conversion import convert_file
 from fileidentification.tasks.inspection import assert_file_integrity, inspect_file
-from fileidentification.tasks.os_tasks import move_tmp, set_filepaths
+from fileidentification.tasks.os_tasks import move_tmp
 from fileidentification.tasks.policies import apply_policy, build_policies
-from fileidentification.workspace import FilePaths, Workspace
+from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import tool_for
 
 
@@ -50,7 +51,6 @@ class FileHandler:
         self.log_tables = LogTables()
         self.ba = BasicAnalytics()
         self.stack: list[SfInfo] = []
-        self.fp: FilePaths = FilePaths()
         self.ws: Workspace = Workspace(Path(), Path())  # replaced in run() once root_folder / tmp are resolved
         self._stack_lock = threading.Lock()
         self._soffice_lock = threading.Semaphore(1)
@@ -62,8 +62,8 @@ class FileHandler:
         otherwhise it scans the root_folder with pygfried and adds its output as sfinfos to the stack
         """
         # if there is a log, try to read from there
-        if self.fp.LOGJSON.is_file():
-            self.stack.extend([SfInfo(**metadata) for metadata in json.loads(self.fp.LOGJSON.read_text())["files"]])
+        if self.ws.logjson.is_file():
+            self.stack.extend([SfInfo(**metadata) for metadata in json.loads(self.ws.logjson.read_text())["files"]])
 
         # scan the root_folder with pygfried only when nothing was reloaded; those files then need relativizing
         initial = not self.stack
@@ -142,13 +142,13 @@ class FileHandler:
         blank.
         """
         # default policies found and no external policies are passed
-        if not policies_path and self.fp.POLJSON.is_file():
+        if not policies_path and self.ws.poljson.is_file():
             # set default location
-            policies_path = self.fp.POLJSON
+            policies_path = self.ws.poljson
         # no default policies found or the blank option is given:
         # fallback: generate the policies with optional flag blank
         if not policies_path or blank:
-            policies_path = self.fp.POLJSON
+            policies_path = self.ws.poljson
             print_msg("Generating policies", self.mode.QUIET)
             self._gen_policies(policies_path, blank=blank)
         # load the external passed policies with option -p or default location
@@ -158,8 +158,8 @@ class FileHandler:
 
         # expand a passed policies with the filetypes found in root_folder that are not yet in the policies
         if extend and policies_path:
-            print_msg(f"Updating the filetypes in policies {self.fp.POLJSON}", self.mode.QUIET)
-            self._gen_policies(self.fp.POLJSON, extend=extend)
+            print_msg(f"Updating the filetypes in policies {self.ws.poljson}", self.mode.QUIET)
+            self._gen_policies(self.ws.poljson, extend=extend)
 
         print_fmts(list(self.ba.puid_unique), self.ba, self.policies, self.mode)
 
@@ -186,13 +186,11 @@ class FileHandler:
                     # the test output is not moved, so it lives in the sample's working dir
                     secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
 
-    def inspect(self) -> None:
+    def inspect(self, to_csv: bool = False) -> None:
         """
-        Probe all active files and write a dated report JSON without modifying any files.
-        Deletes the policies file so the report is not conflated with a processing run.
+        Probe all active files and write a dated report JSON without modifying the source files.
         """
-        self.fp.LOGJSON = self.fp.TMP_DIR / f"{datetime.now(UTC).strftime('%y%m%d')}_report.json"
-        self.fp.POLJSON.unlink(missing_ok=True)
+        self.ws.poljson.unlink(missing_ok=True)
         active = [s for s in self.stack if not (s.status.removed or s.dest)]
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
             prog.add_task(description="Probing the files ...", total=None)
@@ -205,6 +203,7 @@ class FileHandler:
                 )
 
         print_diagnostic(log_tables=self.log_tables, mode=self.mode)
+        self.write_logs(to_csv=to_csv, target=self.ws.report_json(datetime.now(UTC).strftime("%y%m%d")))
 
     def assert_integrity(self) -> None:
         """Probe all active files: remove corrupt ones and rename files with extension mismatches."""
@@ -285,22 +284,26 @@ class FileHandler:
             files_moved = move_tmp(self.stack, self.ws, self.policies, self.log_tables, self.mode.REMOVEORIGINAL)
 
         # remove empty folders in working dir
-        if self.fp.TMP_DIR.is_dir():
-            for path, _, _ in os.walk(self.fp.TMP_DIR, topdown=False):
+        if self.ws.tmp_dir.is_dir():
+            for path, _, _ in os.walk(self.ws.tmp_dir, topdown=False):
                 if len(os.listdir(path)) == 0:  # noqa: PTH208
                     Path(path).rmdir()
         if files_moved:
-            print_msg(f"\nMoved the files from {self.fp.TMP_DIR.stem} to {root_folder.stem} ...", self.mode.QUIET)
+            print_msg(f"\nMoved the files from {self.ws.tmp_dir.stem} to {root_folder.stem} ...", self.mode.QUIET)
 
-    def write_logs(self, to_csv: bool = False) -> None:
-        """Write the run state to _log.json and optionally export a CSV alongside it."""
+    def write_logs(self, to_csv: bool = False, target: Path | None = None) -> None:
+        """
+        Write the run state to `target` (default: _log.json) and optionally export a CSV alongside it.
+        inspect() passes a dated report path so its read-only output stays separate from a processing run.
+        """
+        dest = target or self.ws.logjson
         print_processing_errors(log_tables=self.log_tables)
 
         logoutput = LogOutput(files=self.stack, errors=self.log_tables.dump_errors(), duplicates=self.ba.duplicates)
-        self.fp.LOGJSON.write_text(logoutput.model_dump_json(indent=4, exclude_none=True))
+        dest.write_text(logoutput.model_dump_json(indent=4, exclude_none=True))
 
         if to_csv:
-            with open(f"{self.fp.LOGJSON}.csv", "w") as f:  # noqa: PTH123
+            with open(f"{dest}.csv", "w") as f:  # noqa: PTH123
                 w = csv.DictWriter(f, CSVFIELDS)
                 w.writeheader()
                 [w.writerow(sfinfo2csv(el)) for el in self.stack]
@@ -327,10 +330,12 @@ class FileHandler:
         inspect: bool = False,
     ) -> None:
         root_folder = Path(root_folder)
-        # set dirs / paths
-        set_filepaths(self.fp, root_folder, tmp_dir)
-        # the per-run path calculator (root_folder is normalized to the parent dir for a single-file target)
-        self.ws = Workspace(root_folder, self.fp.TMP_DIR)
+        # resolve the run's paths (validates the root, normalizes a single-file target, creates the tmp dir)
+        try:
+            self.ws = Workspace.for_run(root_folder, tmp_dir)
+        except ValueError:
+            print_root_not_found()
+            raise Exit(1) from None
         # set the mode
         self.mode.REMOVEORIGINAL = remove_original
         self.mode.VERBOSE = mode_verbose
@@ -343,9 +348,10 @@ class FileHandler:
         try:
             # generate policies
             self._resolve_policies(policies_path, blank, extend)
-            # probing the files
+            # inspect is a terminal, read-only mode: write the dated report and stop before any file-altering step
             if inspect:
-                self.inspect()
+                self.inspect(to_csv=to_csv)
+                return
             if assert_integrity:
                 self.assert_integrity()
                 if not apply:

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -187,9 +187,7 @@ class FileHandler:
                     secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
 
     def inspect(self, to_csv: bool = False) -> None:
-        """
-        Probe all active files and write a dated report JSON without modifying the source files.
-        """
+        """Probe all active files and write a dated report JSON without modifying the source files."""
         self.ws.poljson.unlink(missing_ok=True)
         active = [s for s in self.stack if not (s.status.removed or s.dest)]
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:

--- a/fileidentification/tasks/conversion.py
+++ b/fileidentification/tasks/conversion.py
@@ -73,7 +73,7 @@ def convert_file(sfinfo: SfInfo, policies: Policies, ws: Workspace) -> tuple[SfI
 
     # strip abs paths from log output
     processing_log = None
-    logtext = logtext.replace(f"{ws.root_folder}/", "").replace(f"{ws.tdir}/", "")
+    logtext = logtext.replace(f"{ws.root_folder}/", "").replace(f"{ws.tmp_dir}/", "")
     if logtext:
         processing_log = LogMsg(name=f"{args.bin}", msg=logtext)
 

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -1,11 +1,8 @@
 import shutil
-import sys
-from pathlib import Path
 
 from fileidentification.definitions.models import LogMsg, LogTables, Policies, SfInfo
-from fileidentification.definitions.settings import LOGJSON, POLJSON, TMP_DIR
-from fileidentification.tasks.console_output import print_os_error, print_root_not_found
-from fileidentification.workspace import FilePaths, Workspace
+from fileidentification.tasks.console_output import print_os_error
+from fileidentification.workspace import Workspace
 
 
 def remove(sfinfo: SfInfo, ws: Workspace, log_tables: LogTables) -> None:
@@ -60,28 +57,3 @@ def move_tmp(
                 log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
     return write_logs
-
-
-def set_filepaths(fp: FilePaths, root_folder: Path, tmp_dir: Path | None = None) -> None:
-    """
-    Resolve and create the tmp directory and set LOGJSON / POLJSON paths on fp.
-    Defaults to <root_folder>/__fileidentification; if root_folder is a file, uses <parent>/<stem>.
-    An explicit tmp_dir overrides the default.
-    """
-    # assert rootfolder
-    if root_folder.__fspath__() == "." or not root_folder.exists():
-        print_root_not_found()
-        sys.exit(1)
-    fp.TMP_DIR = root_folder / TMP_DIR
-    # if its a file, use stem as tmp dir
-    if root_folder.is_file():
-        fp.TMP_DIR = root_folder.parent / root_folder.stem
-    # if tmp dir is passed externally
-    if tmp_dir:
-        fp.TMP_DIR = tmp_dir
-
-    if not fp.TMP_DIR.is_dir():
-        fp.TMP_DIR.mkdir(parents=True)
-
-    fp.LOGJSON = fp.TMP_DIR / LOGJSON
-    fp.POLJSON = fp.TMP_DIR / POLJSON

--- a/fileidentification/workspace.py
+++ b/fileidentification/workspace.py
@@ -1,27 +1,21 @@
 """
-Run-scoped path types: FilePaths (the resolved tmp dir + its two JSON files) and Workspace (the path calculator).
+The Workspace: the single run-scoped path module. Built once per run by `Workspace.for_run` from the CLI
+root_folder and an optional tmp dir, then never mutated.
 
-The Workspace is constructed fresh each run from the CLI root_folder and the tmp dir; never persisted.
 Portability comes from the relative `filename` stored in _log.json — the Workspace only resolves that portable
-name against wherever the run happens to be right now. `tdir` may live on a different volume (--tmp-dir /
+name against wherever the run happens to be right now. `tmp_dir` may live on a different volume (--tmp-dir /
 external drive), so it is kept independent of root_folder.
+
+The frozen dataclass itself is pure path math: no I/O, no validation, no branching. All of that (validating the
+root, making the single-file decision, creating the tmp dir) lives in the `for_run` factory, so a plain
+`Workspace(root, tmp)` is safe to construct in tests without touching the filesystem.
 """
 
 import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import BaseModel, Field
-
-from fileidentification.definitions.settings import RMV_DIR
-
-
-class FilePaths(BaseModel, validate_assignment=True):
-    """Resolved output paths used throughout a FileHandler run (the tmp dir and the two JSON files in it)."""
-
-    TMP_DIR: Path = Field(default_factory=Path)
-    POLJSON: Path = Field(default_factory=Path)
-    LOGJSON: Path = Field(default_factory=Path)
+from fileidentification.definitions.settings import LOGJSON, POLJSON, RMV_DIR, TMP_DIR
 
 
 @dataclass(frozen=True)
@@ -29,13 +23,45 @@ class Workspace:
     """Maps a file's portable relative `filename` to its absolute, working, and removed locations on disk."""
 
     root_folder: Path
-    tdir: Path
+    tmp_dir: Path
 
-    def __post_init__(self) -> None:
-        # single-file target: the files live in the parent dir (the normalization set_processing_paths did).
-        # frozen dataclass -> object.__setattr__
-        if self.root_folder.is_file():
-            object.__setattr__(self, "root_folder", self.root_folder.parent)
+    @classmethod
+    def for_run(cls, root_folder: Path, tmp_dir: Path | None = None) -> "Workspace":
+        """
+        Resolve the workspace for a run: validate the root, make the single-file decision once, create the tmp dir.
+
+        A single-file target lives in its parent dir, and its default tmp dir is <parent>/<stem>. A directory target
+        defaults to <root>/__fileidentification. An explicit tmp_dir overrides the default (it may be on another
+        volume). Raises ValueError if the root folder does not exist or is the bare current dir; the caller decides
+        how to surface that (print + exit).
+        """
+        if root_folder.__fspath__() == "." or not root_folder.exists():
+            raise ValueError(f"root folder not found: {root_folder}")  # noqa: EM102, TRY003
+
+        if root_folder.is_file():
+            root_folder, default_tmp = root_folder.parent, root_folder.parent / root_folder.stem
+        else:
+            default_tmp = root_folder / TMP_DIR
+        tmp_dir = tmp_dir or default_tmp
+
+        if not tmp_dir.is_dir():
+            tmp_dir.mkdir(parents=True)
+
+        return cls(root_folder, tmp_dir)
+
+    @property
+    def logjson(self) -> Path:
+        """The run's cumulative log file (read by _build_stack, default write target)."""
+        return self.tmp_dir / LOGJSON
+
+    @property
+    def poljson(self) -> Path:
+        """The run's policies file."""
+        return self.tmp_dir / POLJSON
+
+    def report_json(self, ymd: str) -> Path:
+        """Return the dated inspect-report path (a write target kept separate from a processing run's _log.json)."""
+        return self.tmp_dir / f"{ymd}_report.json"
 
     def relativize(self, scanned: Path) -> Path:
         """Make a freshly scanned absolute path relative to root_folder (the portable form persisted in _log.json)."""
@@ -47,11 +73,11 @@ class Workspace:
 
     def working_dir(self, filename: Path) -> Path:
         """
-        Per-file conversion working dir under tdir. The md5 of the relative path keeps duplicate files
+        Per-file conversion working dir under tmp_dir. The md5 of the relative path keeps duplicate files
         with the same basename at different paths from colliding.
         """
         path_hash = hashlib.md5(str(filename).encode()).hexdigest()[:6]  # noqa: S324
-        return self.tdir / f"{filename.name}_{path_hash}"
+        return self.tmp_dir / f"{filename.name}_{path_hash}"
 
     def working_file(self, origin_filename: Path, output_name: str) -> Path:
         """Where a converted file physically sits before it is moved: inside its origin's working dir."""
@@ -59,4 +85,4 @@ class Workspace:
 
     def removed_dest(self, filename: Path) -> Path:
         """Location under _REMOVED for a corrupt / replaced file (the relative subpath is preserved)."""
-        return self.tdir / RMV_DIR / filename
+        return self.tmp_dir / RMV_DIR / filename

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -63,9 +63,7 @@ class TestBuildStack:
         (root / "sub" / "b.jpg").write_bytes(b"y")
 
         fh = FileHandler()
-        fh.fp.TMP_DIR = tmp_path / "tmp"
-        fh.fp.LOGJSON = fh.fp.TMP_DIR / "_log.json"  # absent -> forces a scan
-        fh.ws = make_ws(root, fh.fp.TMP_DIR)
+        fh.ws = make_ws(root, tmp_path / "tmp")  # ws.logjson absent -> forces a scan
         monkeypatch.setattr("fileidentification.filehandling.pygfried", _fake_pygfried())
 
         fh._build_stack(root)
@@ -82,14 +80,14 @@ class TestBuildStack:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         fh = FileHandler()
-        fh.fp.TMP_DIR = tmp_path / "tmp"
-        fh.fp.TMP_DIR.mkdir()
-        fh.fp.LOGJSON = fh.fp.TMP_DIR / "_log.json"
+        tmp = tmp_path / "tmp"
+        tmp.mkdir()
+        fh.ws = make_ws(tmp_path, tmp)
 
         active = make_sfinfo("sub/a.jpg", md5="a" * 32)
         removed = make_sfinfo("sub/b.jpg", md5="b" * 32)
         removed.status.removed = True
-        fh.fp.LOGJSON.write_text(
+        fh.ws.logjson.write_text(
             json.dumps({"files": [json.loads(active.model_dump_json()), json.loads(removed.model_dump_json())]})
         )
 
@@ -145,7 +143,6 @@ class TestRunTriggersReencode:
         fh = FileHandler()
         order: list[str] = []
         # stub out every heavy step so we only observe the branch logic in run()
-        monkeypatch.setattr("fileidentification.filehandling.set_filepaths", lambda *a, **k: None)
         monkeypatch.setattr(fh, "_build_stack", lambda root: order.append("build"))
         monkeypatch.setattr(fh, "_resolve_policies", lambda *a, **k: order.append("policies"))
         monkeypatch.setattr(fh, "assert_integrity", lambda: order.append("assert"))
@@ -164,7 +161,6 @@ class TestRunTriggersReencode:
     def test_reencode_not_called_when_apply_set(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         fh = FileHandler()
         order: list[str] = []
-        monkeypatch.setattr("fileidentification.filehandling.set_filepaths", lambda *a, **k: None)
         monkeypatch.setattr(fh, "_build_stack", lambda root: None)
         monkeypatch.setattr(fh, "_resolve_policies", lambda *a, **k: None)
         monkeypatch.setattr(fh, "assert_integrity", lambda: order.append("assert"))
@@ -246,13 +242,13 @@ class TestGenPolicies:
 class TestReadPolicies:
     def test_missing_file_exits(self, tmp_path: Path) -> None:
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)  # write_logs (on failure) targets ws.logjson
         with pytest.raises(SystemExit):
             fh._read_policies(tmp_path / "missing.json")
 
     def test_invalid_policy_exits(self, tmp_path: Path) -> None:
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)  # write_logs (on failure) targets ws.logjson
         bad = tmp_path / "bad.json"
         bad.write_text(json.dumps({"policies": {"fmt/43": {"bin": "notabin"}}}))
         with pytest.raises(SystemExit):
@@ -278,22 +274,22 @@ class TestResolvePolicies:
 
     def test_generates_when_nothing_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         fh = FileHandler()
-        fh.fp.POLJSON = tmp_path / "_policies.json"  # does not exist
+        fh.ws = make_ws(tmp_path, tmp_path)  # ws.poljson does not exist
         calls = self._spy(fh, monkeypatch)
         fh._resolve_policies(None)
         assert calls["gen"] and not calls["read"]
 
     def test_reads_default_location_when_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         fh = FileHandler()
-        fh.fp.POLJSON = tmp_path / "_policies.json"
-        fh.fp.POLJSON.write_text("{}")
+        fh.ws = make_ws(tmp_path, tmp_path)
+        fh.ws.poljson.write_text("{}")
         calls = self._spy(fh, monkeypatch)
         fh._resolve_policies(None)
-        assert calls["read"] == [fh.fp.POLJSON] and not calls["gen"]
+        assert calls["read"] == [fh.ws.poljson] and not calls["gen"]
 
     def test_reads_external_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         fh = FileHandler()
-        fh.fp.POLJSON = tmp_path / "_policies.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         external = tmp_path / "ext.json"
         calls = self._spy(fh, monkeypatch)
         fh._resolve_policies(external)
@@ -301,7 +297,7 @@ class TestResolvePolicies:
 
     def test_extend_triggers_gen_after_read(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         fh = FileHandler()
-        fh.fp.POLJSON = tmp_path / "_policies.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         external = tmp_path / "ext.json"
         calls = self._spy(fh, monkeypatch)
         fh._resolve_policies(external, extend=True)
@@ -388,7 +384,7 @@ class TestConvert:
     ) -> None:
         # the failed sfinfo appears in both _log.json sections, but its failure entry is recorded only in "errors"
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
         origin.status.pending = True
         fh.stack = [origin]
@@ -403,7 +399,7 @@ class TestConvert:
         fh.convert()
         fh.write_logs()
 
-        data = json.loads(fh.fp.LOGJSON.read_text())
+        data = json.loads(fh.ws.logjson.read_text())
         files_logs = " ".join(log["msg"] for f in data["files"] for log in f.get("processing_logs", []))
         errors_logs = " ".join(log["msg"] for e in data["errors"] for log in e.get("processing_logs", []))
         assert "conversion failed" not in files_logs and "magick boom detail" not in files_logs  # nothing in "files"
@@ -415,7 +411,6 @@ class TestConvert:
     ) -> None:
         # end to end: the bin's log ends up only in the "errors" copy, not in "files", and is never printed
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
         fh.ws = make_ws(tmp_path, tmp_path)
         origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
         origin.status.pending = True
@@ -439,7 +434,7 @@ class TestConvert:
         assert not any(log.name == "magick" for log in origin.processing_logs)
 
         fh.write_logs()
-        data = json.loads(fh.fp.LOGJSON.read_text())
+        data = json.loads(fh.ws.logjson.read_text())
         files_logs = " ".join(log["msg"] for f in data["files"] for log in f.get("processing_logs", []))
         errors_logs = " ".join(log["msg"] for e in data["errors"] for log in e.get("processing_logs", []))
         assert "magick: boom" not in files_logs  # not in "files"
@@ -453,27 +448,27 @@ class TestRemoveTmpCleanup:
     def test_prunes_empty_dirs_but_keeps_nonempty(self, tmp_path: Path) -> None:
         fh = FileHandler()
         fh.mode.QUIET = True
-        fh.fp.TMP_DIR = tmp_path / "tmp"
-        (fh.fp.TMP_DIR / "empty" / "nested").mkdir(parents=True)  # both levels empty
-        (fh.fp.TMP_DIR / "keep").mkdir()
-        (fh.fp.TMP_DIR / "keep" / "file.log").write_bytes(b"x")
+        fh.ws = make_ws(tmp_path, tmp_path / "tmp")
+        (fh.ws.tmp_dir / "empty" / "nested").mkdir(parents=True)  # both levels empty
+        (fh.ws.tmp_dir / "keep").mkdir()
+        (fh.ws.tmp_dir / "keep" / "file.log").write_bytes(b"x")
         fh.stack = []  # nothing to move
 
         fh.remove_tmp(tmp_path)
 
-        assert not (fh.fp.TMP_DIR / "empty").exists()  # empty tree pruned bottom-up
-        assert (fh.fp.TMP_DIR / "keep" / "file.log").is_file()  # non-empty folder untouched
-        assert fh.fp.TMP_DIR.is_dir()  # the (non-empty) tmp root itself survives
+        assert not (fh.ws.tmp_dir / "empty").exists()  # empty tree pruned bottom-up
+        assert (fh.ws.tmp_dir / "keep" / "file.log").is_file()  # non-empty folder untouched
+        assert fh.ws.tmp_dir.is_dir()  # the (non-empty) tmp root itself survives
 
 
 class TestWriteLogs:
     def test_csv_export_writes_header_and_rows(self, tmp_path: Path) -> None:
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         fh.stack = [make_sfinfo("a.jpg"), make_sfinfo("b.jpg")]
         fh.write_logs(to_csv=True)
 
-        assert fh.fp.LOGJSON.is_file()
+        assert fh.ws.logjson.is_file()
         csv_file = tmp_path / "_log.json.csv"
         assert csv_file.is_file()
         lines = csv_file.read_text().splitlines()
@@ -482,7 +477,7 @@ class TestWriteLogs:
 
     def test_no_csv_when_flag_unset(self, tmp_path: Path) -> None:
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         fh.stack = [make_sfinfo("a.jpg")]
         fh.write_logs(to_csv=False)
         assert not (tmp_path / "_log.json.csv").exists()
@@ -492,7 +487,7 @@ class TestWriteLogs:
     ) -> None:
         # regression: print_processing_errors must run before dump_errors() empties the table
         fh = FileHandler()
-        fh.fp.LOGJSON = tmp_path / "_log.json"
+        fh.ws = make_ws(tmp_path, tmp_path)
         sfinfo = make_sfinfo("sub/orig.jpg")
         fh.stack = [sfinfo]
         fh.log_tables.processing_error_add(LogMsg(name="magick", msg="conversion failed [magick] boom"), sfinfo)
@@ -507,9 +502,8 @@ class TestWriteLogs:
 class TestInspectMode:
     def test_writes_dated_report_and_removes_policies(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         fh = FileHandler()
-        fh.fp.TMP_DIR = tmp_path
-        fh.fp.POLJSON = tmp_path / "_policies.json"
-        fh.fp.POLJSON.write_text("{}")
+        fh.ws = make_ws(tmp_path, tmp_path)
+        fh.ws.poljson.write_text("{}")
 
         active = make_sfinfo("a.jpg")
         skipped_removed = make_sfinfo("b.jpg")
@@ -521,8 +515,10 @@ class TestInspectMode:
 
         fh.inspect()
 
-        assert not fh.fp.POLJSON.exists()  # policies file deleted so report is standalone
-        assert fh.fp.LOGJSON.name.endswith("_report.json")
+        assert not fh.ws.poljson.exists()  # policies file deleted so report is standalone
+        reports = list(fh.ws.tmp_dir.glob("*_report.json"))
+        assert len(reports) == 1  # a dated report was written ...
+        assert not fh.ws.logjson.exists()  # ... instead of the canonical processing log
         assert probed == [active]  # removed files are skipped
 
 

--- a/tests/test_os_tasks.py
+++ b/tests/test_os_tasks.py
@@ -5,43 +5,10 @@ from pathlib import Path
 import pytest
 
 from fileidentification.definitions.models import LogTables, PolicyParams, SfInfo
-from fileidentification.definitions.settings import LOGJSON, POLJSON, RMV_DIR, TMP_DIR
-from fileidentification.tasks.os_tasks import move_tmp, remove, set_filepaths
-from fileidentification.workspace import FilePaths, Workspace
+from fileidentification.definitions.settings import RMV_DIR
+from fileidentification.tasks.os_tasks import move_tmp, remove
+from fileidentification.workspace import Workspace
 from tests.conftest import make_sfinfo, make_ws
-
-
-class TestSetFilepaths:
-    def test_directory_root(self, tmp_path: Path) -> None:
-        fp = FilePaths()
-        set_filepaths(fp, tmp_path)
-        assert fp.TMP_DIR == tmp_path / TMP_DIR
-        assert fp.TMP_DIR.is_dir()
-        assert fp.LOGJSON == fp.TMP_DIR / LOGJSON
-        assert fp.POLJSON == fp.TMP_DIR / POLJSON
-
-    def test_file_root_uses_stem(self, tmp_path: Path) -> None:
-        f = tmp_path / "movie.mp4"
-        f.write_bytes(b"x")
-        fp = FilePaths()
-        set_filepaths(fp, f)
-        assert fp.TMP_DIR == tmp_path / "movie"
-        assert fp.TMP_DIR.is_dir()
-
-    def test_custom_tmp_dir_overrides(self, tmp_path: Path) -> None:
-        custom = tmp_path / "elsewhere"
-        fp = FilePaths()
-        set_filepaths(fp, tmp_path, tmp_dir=custom)
-        assert fp.TMP_DIR == custom
-        assert custom.is_dir()
-
-    def test_nonexistent_root_exits(self, tmp_path: Path) -> None:
-        with pytest.raises(SystemExit):
-            set_filepaths(FilePaths(), tmp_path / "does-not-exist")
-
-    def test_dot_root_exits(self) -> None:
-        with pytest.raises(SystemExit):
-            set_filepaths(FilePaths(), Path())
 
 
 class TestRemove:
@@ -57,7 +24,7 @@ class TestRemove:
 
         assert s.status.removed
         assert not f.exists()
-        assert (ws.tdir / RMV_DIR / "bad.mp4").is_file()
+        assert (ws.tmp_dir / RMV_DIR / "bad.mp4").is_file()
 
     def test_missing_source_records_processing_error(self, tmp_path: Path) -> None:
         ws = make_ws(tmp_path / "root", tmp_path / "tdir")
@@ -147,7 +114,7 @@ class TestMoveTmp:
 
         assert original.status.removed is True
         assert not ws.abs_path(original.filename).exists()
-        assert (ws.tdir / RMV_DIR / "sub" / "orig.jpg").is_file()
+        assert (ws.tmp_dir / RMV_DIR / "sub" / "orig.jpg").is_file()
         assert (root / "sub" / "orig.tif").is_file()  # conversion still placed
 
     def test_policy_remove_original_quarantines_even_without_flag(self, tmp_path: Path) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,12 +1,16 @@
-"""Unit tests for the Workspace path calculator.
+"""Unit tests for the Workspace path module.
 
-Pure path arithmetic — no disk is touched except the single-file-target case (which needs a real file
-so `is_file()` fires) and nothing shells out. Covers the portability, cross-volume tmp, and
-duplicate-basename cases the refactor depends on.
+The frozen dataclass is pure path arithmetic — no disk, no shelling out — so it is constructed directly.
+The `for_run` factory is the impure entry point (validate root, normalize a single-file target, create the
+tmp dir); its tests touch a real tmp dir. Covers the portability, cross-volume tmp, and duplicate-basename
+cases the refactor depends on.
 """
 
 from pathlib import Path
 
+import pytest
+
+from fileidentification.definitions.settings import LOGJSON, POLJSON, TMP_DIR
 from fileidentification.workspace import Workspace
 
 
@@ -70,14 +74,44 @@ class TestCrossVolumeTdir:
         assert ws.removed_dest(Path("a.jpg")) == Path("/mnt/external/tmp/_REMOVED/a.jpg")
 
 
-class TestSingleFileTarget:
-    def test_root_folder_normalized_to_parent(self, tmp_path: Path) -> None:
+class TestDerivedPaths:
+    def test_logjson_and_poljson_derive_from_tmp_dir(self) -> None:
+        ws = Workspace(Path("/data/root"), Path("/data/root/__fileidentification"))
+        assert ws.logjson == Path("/data/root/__fileidentification") / LOGJSON
+        assert ws.poljson == Path("/data/root/__fileidentification") / POLJSON
+
+    def test_report_json_is_dated_under_tmp_dir(self) -> None:
+        ws = Workspace(Path("/data/root"), Path("/data/root/__fileidentification"))
+        assert ws.report_json("240101") == Path("/data/root/__fileidentification/240101_report.json")
+
+
+class TestForRun:
+    def test_directory_root_defaults_tmp_and_creates_it(self, tmp_path: Path) -> None:
+        ws = Workspace.for_run(tmp_path)
+        assert ws.root_folder == tmp_path
+        assert ws.tmp_dir == tmp_path / TMP_DIR
+        assert ws.tmp_dir.is_dir()
+        assert ws.logjson == tmp_path / TMP_DIR / LOGJSON
+
+    def test_file_root_normalizes_to_parent_and_uses_stem_tmp(self, tmp_path: Path) -> None:
         f = tmp_path / "solo.jpg"
         f.write_bytes(b"x")
-        ws = Workspace(f, tmp_path / "tmp")
-        assert ws.root_folder == tmp_path
+        ws = Workspace.for_run(f)
+        assert ws.root_folder == tmp_path  # single file -> parent is the root
+        assert ws.tmp_dir == tmp_path / "solo"  # stem is the default tmp dir
+        assert ws.tmp_dir.is_dir()
         assert ws.abs_path(Path("solo.jpg")) == tmp_path / "solo.jpg"
 
-    def test_directory_target_is_left_as_is(self, tmp_path: Path) -> None:
-        ws = Workspace(tmp_path, tmp_path / "tmp")
-        assert ws.root_folder == tmp_path
+    def test_custom_tmp_dir_overrides_and_is_created(self, tmp_path: Path) -> None:
+        custom = tmp_path / "elsewhere"
+        ws = Workspace.for_run(tmp_path, tmp_dir=custom)
+        assert ws.tmp_dir == custom
+        assert custom.is_dir()
+
+    def test_nonexistent_root_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="root folder not found"):
+            Workspace.for_run(tmp_path / "does-not-exist")
+
+    def test_dot_root_raises(self) -> None:
+        with pytest.raises(ValueError, match="root folder not found"):
+            Workspace.for_run(Path())


### PR DESCRIPTION
## What

Makes `Workspace` the single run-scoped path module, continuing the #106 "extract Workspace" refactor.

- `Workspace.for_run(root, tmp_dir=None)` is now the one entry point: it validates the root, makes the single-file→parent decision **once**, and creates the tmp dir. The frozen dataclass itself is pure path math (no I/O, no `__post_init__` branching).
- `logjson` / `poljson` are derived properties; `report_json(ymd)` gives the inspect report path.
- **Deleted** `FilePaths` and `os_tasks.set_filepaths` — the single-file normalization used to live in both `set_filepaths` (via stem) and `Workspace.__post_init__` (via parent); now it's computed once.
- `for_run` **raises `ValueError`** on a bad root; `run()` catches it, prints, and exits — the path module no longer imports console output or calls `sys.exit`.
- Renamed `ws.tdir` → `ws.tmp_dir` to match the derived accessors.
- `--inspect` is now **terminal**: it writes its own dated `_report.json` and `run()` returns before any source-altering step. This removes the mutable write target (formerly `fp.LOGJSON`, briefly `log_target`); `write_logs` defaults to `ws.logjson` and takes an optional `target`.

## Behavior change

`--inspect` combined with `-a` / `-r` previously ran those steps and wrote to the report. Now `--inspect` is read-only and returns before them, so those flags are ignored when it is set. This matches the intent of `--inspect` (touch no source files).

## Testing

- `ruff check` clean, `ruff format --check` clean, `mypy` (strict) clean
- `pytest -m "not docker"` — **180 passed**
- Docker tests (12) not run here — need the real toolchain; worth `just dockerise && pytest -m docker` before merge (exercises the single-file-target path end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)