### PR TITLE
refactor: FileHandler cleanup (Workspace, stack lifecycle, parallel runner, output)

### DIFF
--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -85,6 +85,10 @@ class SfInfo(BaseModel):
             return puid
         return None
 
+    @property
+    def is_active(self) -> bool:
+        return not (self.status.removed or self.dest)
+
 
 class LogOutput(BaseModel):
     """Top-level structure written to _log.json: all files, processing errors, and duplicates."""

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import threading
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from datetime import UTC, datetime
@@ -185,19 +186,22 @@ class FileHandler:
                     # the test output is not moved, so it lives in the sample's working dir
                     secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
 
+    def _run_parallel(self, items: Iterable[SfInfo], description: str, work: Callable[[SfInfo], object]) -> None:
+        """Run `work` over `items` on the thread pool under a transient spinner labelled `description`."""
+        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
+            prog.add_task(description=description, total=None)
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                list(executor.map(work, items))
+
     def inspect(self, to_csv: bool = False) -> None:
         """Probe all active files and write a dated report JSON without modifying the source files."""
         self.ws.poljson.unlink(missing_ok=True)
         active = [s for s in self.stack if s.is_active]
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
-            prog.add_task(description="Probing the files ...", total=None)
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                list(
-                    executor.map(
-                        lambda sfinfo: inspect_file(sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE),
-                        active,
-                    )
-                )
+        self._run_parallel(
+            active,
+            "Probing the files ...",
+            lambda sfinfo: inspect_file(sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE),
+        )
 
         print_diagnostic(log_tables=self.log_tables, mode=self.mode)
         self.write_logs(to_csv=to_csv, target=self.ws.report_json(datetime.now(UTC).strftime("%y%m%d")))
@@ -205,17 +209,11 @@ class FileHandler:
     def assert_integrity(self) -> None:
         """Probe all active files: remove corrupt ones and rename files with extension mismatches."""
         active = [s for s in self.stack if s.is_active]
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
-            prog.add_task(description="Probing the files ...", total=None)
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                list(
-                    executor.map(
-                        lambda sfinfo: assert_file_integrity(
-                            sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE
-                        ),
-                        active,
-                    )
-                )
+        self._run_parallel(
+            active,
+            "Probing the files ...",
+            lambda sfinfo: assert_file_integrity(sfinfo, self.policies, self.ws, self.log_tables, self.mode.VERBOSE),
+        )
 
         print_diagnostic(log_tables=self.log_tables, mode=self.mode)
 
@@ -233,15 +231,11 @@ class FileHandler:
     def apply_policies(self) -> None:
         """Evaluate the policy for every active file and mark those that need conversion as pending."""
         active = [s for s in self.stack if s.is_active]
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
-            prog.add_task(description="Applying policies ...", total=None)
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                list(
-                    executor.map(
-                        lambda sfinfo: apply_policy(sfinfo, self.policies, self.ws, self.log_tables, self.mode.STRICT),
-                        active,
-                    )
-                )
+        self._run_parallel(
+            active,
+            "Applying policies ...",
+            lambda sfinfo: apply_policy(sfinfo, self.policies, self.ws, self.log_tables, self.mode.STRICT),
+        )
 
     def convert(self) -> None:
         """Convert files whose metadata status pending is True"""
@@ -269,10 +263,7 @@ class FileHandler:
                 # the bin's log (if any) goes in as a detail: recorded in the "errors" copy but not printed
                 self.log_tables.processing_error_add(lmsg, sfinfo, [bin_log] if bin_log else None)
 
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
-            prog.add_task(description="Converting ...", total=None)
-            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                list(executor.map(_convert_one, pending))
+        self._run_parallel(pending, "Converting ...", _convert_one)
 
     def remove_tmp(self, root_folder: Path) -> None:
         """Move converted files from the tmp dir to their destinations and clean up empty tmp folders."""

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -82,7 +82,7 @@ class FileHandler:
         for sfinfo in self.stack:
             if initial and not sfinfo.status.removed:
                 sfinfo.filename = self.ws.relativize(sfinfo.filename)
-            if not (sfinfo.status.removed or sfinfo.dest):
+            if sfinfo.is_active:
                 self.ba.append(sfinfo)
 
         print_siegfried_errors(ba=self.ba)
@@ -189,7 +189,7 @@ class FileHandler:
     def inspect(self, to_csv: bool = False) -> None:
         """Probe all active files and write a dated report JSON without modifying the source files."""
         self.ws.poljson.unlink(missing_ok=True)
-        active = [s for s in self.stack if not (s.status.removed or s.dest)]
+        active = [s for s in self.stack if s.is_active]
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
             prog.add_task(description="Probing the files ...", total=None)
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -205,7 +205,7 @@ class FileHandler:
 
     def assert_integrity(self) -> None:
         """Probe all active files: remove corrupt ones and rename files with extension mismatches."""
-        active = [s for s in self.stack if not (s.status.removed or s.dest)]
+        active = [s for s in self.stack if s.is_active]
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
             prog.add_task(description="Probing the files ...", total=None)
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -233,7 +233,7 @@ class FileHandler:
 
     def apply_policies(self) -> None:
         """Evaluate the policy for every active file and mark those that need conversion as pending."""
-        active = [s for s in self.stack if not (s.status.removed or s.dest)]
+        active = [s for s in self.stack if s.is_active]
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
             prog.add_task(description="Applying policies ...", total=None)
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -200,7 +200,7 @@ class FileHandler:
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
+            BarColumn(complete_style="green", finished_style="green"),
             MofNCompleteColumn(),
             TimeElapsedColumn(),
             transient=True,

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -3,14 +3,14 @@ import json
 import os
 import sys
 import threading
-from collections.abc import Callable, Iterable
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pygfried
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from typer import Exit, colors, secho
 
 from fileidentification.definitions.models import (
@@ -186,12 +186,24 @@ class FileHandler:
                     # the test output is not moved, so it lives in the sample's working dir
                     secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
 
-    def _run_parallel(self, items: Iterable[SfInfo], description: str, work: Callable[[SfInfo], object]) -> None:
-        """Run `work` over `items` on the thread pool under a transient spinner labelled `description`."""
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as prog:
-            prog.add_task(description=description, total=None)
+    def _run_parallel(self, items: list[SfInfo], description: str, work: Callable[[SfInfo], object]) -> None:
+        """
+        Run `work` over `items` on the thread pool, showing a progress bar (labelled `description`) that
+        advances as each file completes. Exceptions raised by `work` propagate via future.result().
+        """
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            transient=True,
+        ) as prog:
+            task = prog.add_task(description=description, total=len(items))
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-                list(executor.map(work, items))
+                for future in as_completed([executor.submit(work, item) for item in items]):
+                    future.result()
+                    prog.advance(task)
 
     def inspect(self, to_csv: bool = False) -> None:
         """Probe all active files and write a dated report JSON without modifying the source files."""

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -24,7 +24,7 @@ from fileidentification.definitions.models import (
     SfInfo,
     sfinfo2csv,
 )
-from fileidentification.definitions.settings import CSVFIELDS, DEFAULTPOLICIES, MAX_WORKERS, PYG_WORKERS
+from fileidentification.definitions.settings import CSVFIELDS, DEFAULTPOLICIES, MAX_WORKERS, PYG_WORKERS, Bin
 from fileidentification.tasks.console_output import (
     print_diagnostic,
     print_duplicates,
@@ -39,7 +39,6 @@ from fileidentification.tasks.inspection import assert_file_integrity, inspect_f
 from fileidentification.tasks.os_tasks import move_tmp
 from fileidentification.tasks.policies import apply_policy, build_policies
 from fileidentification.workspace import Workspace
-from fileidentification.wrappers.tools import tool_for
 
 
 class FileHandler:
@@ -254,8 +253,9 @@ class FileHandler:
             return
 
         def _convert_one(sfinfo: SfInfo) -> None:
-            tool = tool_for(self.policies[sfinfo.processed_as].bin)  # type: ignore[index]
-            ctx = self._soffice_lock if tool and tool.serialized_run else nullcontext()
+            # soffice cannot run concurrent instances, so serialize its conversions through the lock
+            soffice = self.policies[sfinfo.processed_as].bin == Bin.SOFFICE  # type: ignore[index]
+            ctx = self._soffice_lock if soffice else nullcontext()
             with ctx:
                 conv_sfinfo, cmd, bin_log = convert_file(sfinfo, self.policies, self.ws)
             if conv_sfinfo:

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -180,11 +180,17 @@ class FileHandler:
                 # we want the smallest file first for running the test
                 sample = self.ba.smallest_file(puid)
                 secho(f"\n{puid}", fg=colors.YELLOW)
-                t_sfinfo, cmd, _ = convert_file(sample, self.policies, self.ws)
+                t_sfinfo, cmd, bin_log = convert_file(sample, self.policies, self.ws)
                 if t_sfinfo:
                     secho(f"{cmd}", fg=colors.GREEN, bold=True)
-                    # the test output is not moved, so it lives in the sample's working dir
-                    secho(f"You find the file with the log in {self.ws.working_dir(sample.filename)}")
+                else:
+                    # the conversion test failed: surface why (this path is interactive, so print it now)
+                    reason = sample.processing_logs[-1].msg if sample.processing_logs else "conversion failed"
+                    secho(f"{reason}", fg=colors.RED, bold=True)
+                    secho(f"{cmd}")
+                    if bin_log:
+                        secho(f"{bin_log.name}: {bin_log.msg}")
+                secho(f"You find the file (if any) in {self.ws.working_dir(sample.filename)}")
 
     def _run_parallel(self, items: list[SfInfo], description: str, work: Callable[[SfInfo], object]) -> None:
         """

--- a/fileidentification/tasks/console_output.py
+++ b/fileidentification/tasks/console_output.py
@@ -58,7 +58,8 @@ def print_fmts(puids: list[str], ba: BasicAnalytics, policies: Policies, mode: M
 
 def print_diagnostic(log_tables: LogTables, mode: Mode) -> None:
     """
-    Print corruption errors always, and (in verbose mode) warnings and extension mismatches.
+    Print corruption errors always, and (unless quiet) warnings and extension mismatches.
+    --verbose controls how deeply files are probed, not what is reported here.
     Each entry shows file size, filename, and the associated log messages.
     """
     # lists all corrupt files with the respective errors thrown
@@ -68,7 +69,7 @@ def print_diagnostic(log_tables: LogTables, mode: Mode) -> None:
             for sfinfo in log_tables.diagnostics[FDMsg.ERROR.name]:
                 secho(f"\n{_format_bite_size(sfinfo.filesize): >10}    {sfinfo.filename}", bold=True)
                 _print_logs(sfinfo.warnings)
-        if mode.VERBOSE and not mode.QUIET:
+        if not mode.QUIET:
             if FDMsg.WARNING.name in log_tables.diagnostics:
                 secho("\n----------- Warnings -----------", bold=True)
                 for sfinfo in log_tables.diagnostics[FDMsg.WARNING.name]:
@@ -116,44 +117,9 @@ def print_msg(msg: str, quiet: bool) -> None:
         secho(msg)
 
 
-# inline messages emitted by the task modules while processing a single file.
-# these are errors / warnings, so they are shown regardless of quiet mode.
-
-
-def print_manual_rename_warning(filename: Path, hint: str) -> None:
-    """Warn that a file with an extension mismatch has to be renamed by hand (several possible extensions)."""
-    secho(f"\nWARNING: you should manually rename {filename}", fg=colors.YELLOW)
-    secho(hint, fg=colors.YELLOW)
-
-
-def print_empty_source_warning(filename: Path) -> None:
-    """Warn that a file has an empty source."""
-    secho(f"\nWARNING: {filename} has empty source", fg=colors.YELLOW)
-
-
-def print_os_error(error: str) -> None:
-    """Report a filesystem error (rename / move / remove failure)."""
-    secho(error, fg=colors.RED)
-
-
 def print_root_not_found() -> None:
     """Report that the given root folder does not exist."""
     secho("root folder not found", fg=colors.RED)
-
-
-def print_unexpected_format_error(detail: str, filename: Path, target: Path) -> None:
-    """Report that a conversion produced a file in an unexpected format."""
-    secho(f"\tERROR: {detail} when converting {filename} to {target}", fg=colors.YELLOW, bold=True)
-
-
-def print_conversion_failed_error(filename: Path, target: Path) -> None:
-    """Report that a conversion produced no output file."""
-    secho(f"\tERROR failed to convert {filename} to {target}", fg=colors.RED, bold=True)
-
-
-def print_invalid_streams_error(filename: Path) -> None:
-    """Report that ffprobe could not read the streams of a file flagged for a stream check."""
-    secho(f"\t{filename} throwing errors. consider file", fg=colors.RED, bold=True)
 
 
 def _format_bite_size(bytes_size: int) -> str:

--- a/fileidentification/tasks/conversion.py
+++ b/fileidentification/tasks/conversion.py
@@ -4,7 +4,6 @@ import pygfried
 
 from fileidentification.definitions.models import LogMsg, Policies, PolicyParams, SfInfo
 from fileidentification.definitions.settings import FPMsg
-from fileidentification.tasks.console_output import print_conversion_failed_error, print_unexpected_format_error
 from fileidentification.workspace import Workspace
 from fileidentification.wrappers.converter import convert
 from fileidentification.wrappers.tools import MediaTool, tool_for
@@ -46,13 +45,11 @@ def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
         else:
             p_error = f" did expect {expected}, got {target_sfinfo.processed_as} instead"
             sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{FPMsg.NOTEXPECTEDFMT}{p_error}"))
-            print_unexpected_format_error(p_error, sfinfo.filename, target)
             target_sfinfo = None
 
     else:
         # conversion error, nothing to analyse
         sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{FPMsg.CONVFAILED}"))
-        print_conversion_failed_error(sfinfo.filename, target)
 
     return target_sfinfo
 

--- a/fileidentification/tasks/inspection.py
+++ b/fileidentification/tasks/inspection.py
@@ -1,10 +1,5 @@
 from fileidentification.definitions.models import LogMsg, LogTables, Policies, SfInfo
 from fileidentification.definitions.settings import FMT2EXT, FDMsg, FPMsg
-from fileidentification.tasks.console_output import (
-    print_empty_source_warning,
-    print_manual_rename_warning,
-    print_os_error,
-)
 from fileidentification.tasks.os_tasks import remove
 from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import MediaTool, tool_for, tool_from_mime
@@ -16,7 +11,7 @@ def assert_file_integrity(
     """
     Probe the file and act on the result: remove it if corrupt, rename it if the extension is wrong.
     If the format has only one known extension, the rename is done automatically;
-    otherwise a manual rename warning is printed.
+    otherwise it is flagged in the diagnostics for a manual rename.
     """
     res: FDMsg | None = inspect_file(sfinfo, policies, ws, log_tables, verbose)
     if res == FDMsg.ERROR:
@@ -26,7 +21,10 @@ def assert_file_integrity(
             ext = "." + FMT2EXT[sfinfo.processed_as]["file_extensions"][-1]  # type: ignore[index]
             _rename(sfinfo, ext, ws, log_tables)
         else:
-            print_manual_rename_warning(sfinfo.filename, sfinfo.processing_logs[0].msg)
+            # several possible extensions: cannot auto-rename, so flag it for a manual rename in the report
+            sfinfo.processing_logs.append(
+                LogMsg(name="filehandler", msg="several possible extensions, rename manually")
+            )
 
 
 def inspect_file(
@@ -56,8 +54,8 @@ def inspect_file(
         return FDMsg.ERROR
 
     if sfinfo.errors == FDMsg.EMPTYSOURCE:
-        sfinfo.processing_logs.append(LogMsg(name="siegfried", msg=FDMsg.EMPTYSOURCE))
-        print_empty_source_warning(sfinfo.filename)
+        # record as a warning so the end-of-phase report surfaces it (the WARNING bucket prints sfinfo.warnings)
+        sfinfo.warnings.append(LogMsg(name="siegfried", msg=FDMsg.EMPTYSOURCE))
         log_tables.diagnostics_add(sfinfo, FDMsg.WARNING)
 
     # extension mismatch
@@ -86,7 +84,6 @@ def _rename(sfinfo: SfInfo, ext: str, ws: Workspace, log_tables: LogTables) -> N
         sfinfo.filename = ws.relativize(dest)
         sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=msg))
     except OSError as e:
-        print_os_error(str(e))
         log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
 

--- a/fileidentification/tasks/inspection.py
+++ b/fileidentification/tasks/inspection.py
@@ -21,10 +21,7 @@ def assert_file_integrity(
             ext = "." + FMT2EXT[sfinfo.processed_as]["file_extensions"][-1]  # type: ignore[index]
             _rename(sfinfo, ext, ws, log_tables)
         else:
-            # several possible extensions: cannot auto-rename, so flag it for a manual rename in the report
-            sfinfo.processing_logs.append(
-                LogMsg(name="filehandler", msg="several possible extensions, rename manually")
-            )
+            sfinfo.processing_logs.append(LogMsg(name="filehandler", msg="you should manually rename the file"))
 
 
 def inspect_file(

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -1,7 +1,6 @@
 import shutil
 
 from fileidentification.definitions.models import LogMsg, LogTables, Policies, SfInfo
-from fileidentification.tasks.console_output import print_os_error
 from fileidentification.workspace import Workspace
 
 
@@ -14,7 +13,6 @@ def remove(sfinfo: SfInfo, ws: Workspace, log_tables: LogTables) -> None:
         sfinfo.status.removed = True
         #  sfinfo.processing_logs.append(LogMsg(name="filehandler", msg="file removed"))
     except OSError as e:
-        print_os_error(str(e))
         log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
 
@@ -53,7 +51,6 @@ def move_tmp(
                 sfinfo.status.added = True
                 sfinfo.dest = None
             except OSError as e:
-                print_os_error(str(e))
                 log_tables.processing_error_add(LogMsg(name="filehandler", msg=str(e)), sfinfo)
 
     return write_logs

--- a/fileidentification/tasks/policies.py
+++ b/fileidentification/tasks/policies.py
@@ -1,8 +1,7 @@
 from collections.abc import Iterable
 
 from fileidentification.definitions.models import LogMsg, LogTables, Mode, Policies, PolicyParams, SfInfo
-from fileidentification.definitions.settings import FMT2EXT, PLMsg
-from fileidentification.tasks.console_output import print_invalid_streams_error
+from fileidentification.definitions.settings import FMT2EXT, FDMsg, PLMsg
 from fileidentification.tasks.os_tasks import remove
 from fileidentification.workspace import Workspace
 from fileidentification.wrappers.ffmpeg import ffmpeg_media_info
@@ -85,16 +84,18 @@ def apply_policy(sfinfo: SfInfo, policies: Policies, ws: Workspace, log_tables: 
         return
 
     # check if mp4 / mkv has correct stream (i.e. h264 and aac)
-    if puid in ["fmt/199", "fmt/569"] and _has_invalid_streams(sfinfo, puid, ws):
+    if puid in ["fmt/199", "fmt/569"] and _has_invalid_streams(sfinfo, puid, ws, log_tables):
         sfinfo.status.pending = True
         return
 
 
-def _has_invalid_streams(sfinfo: SfInfo, puid: str, ws: Workspace) -> bool:
+def _has_invalid_streams(sfinfo: SfInfo, puid: str, ws: Workspace, log_tables: LogTables) -> bool:
     """Return true if video and audio codec differ from archival standards"""
     streams = ffmpeg_media_info(ws.abs_path(sfinfo.filename))
     if not streams:
-        print_invalid_streams_error(sfinfo.filename)
+        # ffprobe read no streams for a file we meant to stream-check: record a warning for the end-of-phase report
+        sfinfo.warnings.append(LogMsg(name="ffmpeg", msg="could not read streams for the a/v stream check"))
+        log_tables.diagnostics_add(sfinfo, FDMsg.WARNING)
         return False
     if puid in ["fmt/569"]:
         # only the video codec has to be ffv1 -> return false as soon as any stream is ffv1

--- a/fileidentification/wrappers/tools.py
+++ b/fileidentification/wrappers/tools.py
@@ -2,9 +2,9 @@
 The MediaTool seam: one interface over the external tools (ffmpeg, imagemagick, soffice).
 
 Every place that used to dispatch on the ``bin`` string with its own ``match`` — building the conversion command,
-probing for corruption, extracting media info, deciding whether a run must be serialized — now goes through a
-MediaTool adapter, so each tool's quirks live with the tool. Resolve a tool with ``tool_for`` (from a policy's bin)
-or ``tool_from_mime`` (from a mimetype); both return None when no tool applies.
+probing for corruption, extracting media info — now goes through a MediaTool adapter, so each tool's quirks live
+with the tool. Resolve a tool with ``tool_for`` (from a policy's bin) or ``tool_from_mime`` (from a mimetype);
+both return None when no tool applies.
 """
 
 import json
@@ -41,11 +41,9 @@ class MediaTool(ABC):
     """
     An external tool (ffmpeg / imagemagick / soffice) behind a single interface.
     ``bin`` is the executable key used in policies and as the log label for probe output.
-    ``serialized_run`` is True for tools that must not run concurrently (soffice).
     """
 
     bin: str
-    serialized_run: bool = False
 
     @abstractmethod
     def build_command(self, source: Path, args: PolicyParams, target: Path, wdir: Path) -> list[str]:
@@ -102,10 +100,9 @@ class Imagemagick(MediaTool):
 
 
 class Soffice(MediaTool):
-    """LibreOffice (soffice): office documents. Must run one conversion at a time."""
+    """LibreOffice (soffice): office documents. Must run one conversion at a time (serialized by the caller)."""
 
     bin = Bin.SOFFICE
-    serialized_run = True
 
     def build_command(self, source: Path, args: PolicyParams, target: Path, wdir: Path) -> list[str]:
         soffice_filter = f"pdf{PDFSETTINGS}" if args.target_container == "pdf" else args.target_container

--- a/tests/test_console_output.py
+++ b/tests/test_console_output.py
@@ -1,54 +1,10 @@
-"""Presentation seam: the inline task messages now live in console_output and are testable in isolation."""
-
-from pathlib import Path
+"""Presentation seam: the console_output helpers, testable in isolation."""
 
 import pytest
 
-from fileidentification.tasks.console_output import (
-    print_conversion_failed_error,
-    print_empty_source_warning,
-    print_invalid_streams_error,
-    print_manual_rename_warning,
-    print_os_error,
-    print_root_not_found,
-    print_unexpected_format_error,
-)
-
-
-def test_manual_rename_warning_shows_filename_and_hint(capsys: pytest.CaptureFixture[str]) -> None:
-    print_manual_rename_warning(Path("sub/pic.jpg"), "expecting one of the following ext: ['tif']")
-    out = capsys.readouterr().out
-    assert "you should manually rename sub/pic.jpg" in out
-    assert "expecting one of the following ext: ['tif']" in out
-
-
-def test_empty_source_warning(capsys: pytest.CaptureFixture[str]) -> None:
-    print_empty_source_warning(Path("empty.bin"))
-    assert "empty.bin has empty source" in capsys.readouterr().out
-
-
-def test_os_error_passthrough(capsys: pytest.CaptureFixture[str]) -> None:
-    print_os_error("[Errno 13] Permission denied")
-    assert "[Errno 13] Permission denied" in capsys.readouterr().out
+from fileidentification.tasks.console_output import print_root_not_found
 
 
 def test_root_not_found(capsys: pytest.CaptureFixture[str]) -> None:
     print_root_not_found()
     assert "root folder not found" in capsys.readouterr().out
-
-
-def test_unexpected_format_error_names_source_and_target(capsys: pytest.CaptureFixture[str]) -> None:
-    print_unexpected_format_error(" did expect ['fmt/353'], got fmt/43 instead", Path("a.jpg"), Path("a.tif"))
-    out = capsys.readouterr().out
-    assert "did expect ['fmt/353'], got fmt/43 instead" in out
-    assert "converting a.jpg to a.tif" in out
-
-
-def test_conversion_failed_error_names_source_and_target(capsys: pytest.CaptureFixture[str]) -> None:
-    print_conversion_failed_error(Path("a.jpg"), Path("a.tif"))
-    assert "failed to convert a.jpg to a.tif" in capsys.readouterr().out
-
-
-def test_invalid_streams_error(capsys: pytest.CaptureFixture[str]) -> None:
-    print_invalid_streams_error(Path("clip.mp4"))
-    assert "clip.mp4 throwing errors" in capsys.readouterr().out

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -554,3 +554,25 @@ class TestTestPolicies:
         monkeypatch.setattr("fileidentification.filehandling.convert_file", record)
         fh._test_policies()
         assert called == []
+
+    def test_failed_policy_test_prints_reason_and_bin_log(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # a failing sample test must still surface the failure (this path prints immediately, no progress bar)
+        fh = _fh_with_puids("fmt/199")
+        sample = make_sfinfo("small.mp4", puid="fmt/199", filesize=1)
+        sample.processing_logs.append(LogMsg(name="filehandler", msg="did expect ['fmt/199'], got fmt/5 instead"))
+        fh.ba.puid_unique["fmt/199"] = [sample]
+        fh.policies = {
+            "fmt/199": PolicyParams(accepted=False, bin="ffmpeg", target_container="mp4", expected=["fmt/199"])
+        }
+        monkeypatch.setattr(
+            "fileidentification.filehandling.convert_file",
+            lambda s, p, ws: (None, ["ffmpeg -i in out"], LogMsg(name="ffmpeg", msg="stream error")),
+        )
+
+        fh._test_policies()
+
+        out = capsys.readouterr().out
+        assert "got fmt/5 instead" in out  # the failure reason from the sample's logs
+        assert "stream error" in out  # the converter's own log

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -84,7 +84,7 @@ class TestInspectFileOutcomes:
         s = make_sfinfo(puid="fmt/43", mime="image/jpeg")
         s.errors = FDMsg.EMPTYSOURCE
         assert inspect_file(s, {}, WS, LogTables(), verbose=False) is None
-        assert any(FDMsg.EMPTYSOURCE in log.msg for log in s.processing_logs)
+        assert any(FDMsg.EMPTYSOURCE in log.msg for log in s.warnings)
 
     def test_extension_mismatch_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(insp, "_has_error", lambda *a, **k: False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -89,6 +89,26 @@ class TestSfInfoModelPostInit:
         assert not s.status.pending
 
 
+class TestSfInfoIsActive:
+    def test_fresh_file_is_active(self) -> None:
+        assert make_sfinfo().is_active
+
+    def test_pending_file_is_still_active(self) -> None:
+        s = make_sfinfo()
+        s.status.pending = True
+        assert s.is_active  # pending files are still in play
+
+    def test_removed_file_is_not_active(self) -> None:
+        s = make_sfinfo()
+        s.status.removed = True
+        assert not s.is_active
+
+    def test_conversion_output_with_dest_is_not_active(self) -> None:
+        s = make_sfinfo()
+        s.dest = Path("sub")
+        assert not s.is_active
+
+
 class TestLogTables:
     def test_diagnostics_add_groups_by_message(self) -> None:
         lt = LogTables()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -38,13 +38,6 @@ class TestResolution:
         assert tool_from_mime("") is None
 
 
-class TestSerializedRun:
-    def test_only_soffice_is_serialized(self) -> None:
-        assert Soffice().serialized_run is True
-        assert Ffmpeg().serialized_run is False
-        assert Imagemagick().serialized_run is False
-
-
 class TestBuildCommand:
     def _args(self, **kw: object) -> PolicyParams:
         base = {"accepted": False, "target_container": "x", "expected": ["fmt/1"]}


### PR DESCRIPTION
Seven focused, mostly behavior-neutral changes to `FileHandler` and the task modules. Each was scoped deliberately to avoid over-abstraction.

## Commits

1. **`refactor: name the active-file predicate as SfInfo.is_active`** — the `not (removed or dest)` predicate was duplicated 4×; now one `SfInfo.is_active` property. (Chose this over a full `Stack` wrapper — the other proposed query methods were single-use.)
2. **`refactor: drop serialized_run flag, gate soffice lock on bin`** — `serialized_run` had one implementer and one reader, and the lock it controlled already lived on `FileHandler`; decide serialization from the bin at the call site. Removes a one-member interface axis and an otherwise-unneeded `tool_for` call.
3. **`refactor: extract _run_parallel`** — the `Progress + ThreadPoolExecutor + executor.map` scaffold was duplicated 4×; now one helper. (Deliberately did **not** add a `RunContext` — it would duplicate `FileHandler`'s state and churn ~34 test sites for no real gain.)
4. **`feat: progress bar per parallel step`** — determinate bar (description, bar, M/N files, elapsed) advancing on each file's completion via `submit` + `as_completed`. No ETA column — per-file cost varies too much to estimate honestly. Throughput unchanged.
5. **`refactor: collect worker messages, report after the progress bar`** — worker threads no longer `secho` mid-run (which garbled the bar). Everything is recorded and surfaced by the end-of-phase reporters. `print_diagnostic` now shows warnings/extension-mismatches unless `--quiet` (was gated behind `--verbose`); `--verbose` keeps controlling probe depth. Six now-dead `print_*` helpers removed.
6. **`fix: report policy-test (-t) failures again`** — the console cleanup removed the inline prints the `-t` path silently relied on; restore failure reporting for that interactive, sequential path.
7. **`style: render the progress bar in green`**

## Notes
- `#4` is the only user-facing feature and could be split into its own PR if preferred.
- `#5` changes default output: warnings that previously required `-v` now show by default (and are no longer interleaved with the bar).

## Testing
- `ruff check` / `ruff format --check` / `mypy` (strict) — all clean
- `pytest -m "not docker"` — 178 passed
- `pytest -m docker` (e2e against the real container) — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)