### PR TITLE
feat: LogMsg level + additional status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ just dasch          # DaSCH-specific: use dasch_policies.json as default, then d
 - **`SfInfo`** — primary metadata object per file; wraps siegfried output and accumulates its processing log (`processing_logs`), status, media info, and derived file info. The `processed_as` field holds the matched PUID.
 - **`PolicyParams`** — one policy entry: `bin` (ffmpeg/magick/soffice), `accepted`, `target_container`, `processing_args`, `expected` (list of PUIDs to verify output), `remove_original`
 - **`BasicAnalytics`** — groups `SfInfo` objects by PUID and tracks duplicates (by MD5)
-- **`RunJournal`** — the single record of what happened to each file during a run. `diagnose` writes a diagnostic (appends the message to the `SfInfo`'s `processing_logs` and buckets the file by `FDMsg` severity for the console report, which prints each bucketed file's `processing_logs`); `record_error` records a processing failure; `error_records` returns the `"errors"`-section copies non-destructively (so the console and persisted views can be produced in any order). Thread-safe: `diagnose` and `record_error` hold an internal `threading.Lock`.
+- **`LogMsg`** — one timestamped log entry (`name`, `msg`, `level`, `timestamp`); `level` is a `LogLevel` (info/warning/error, default info) set by the journal and at explicit error sites.
+- **`RunJournal`** — the single record of what happened to each file during a run. `diagnose` writes a diagnostic (appends the message to the `SfInfo`'s `processing_logs`, sets its `level` from the `FDMsg` severity, and buckets the file by severity for the console report, which prints each bucketed file's `processing_logs`); `record_error` records a processing failure (marking the summary error-level); `error_records` returns the `"errors"`-section copies non-destructively (so the console and persisted views can be produced in any order). Thread-safe: `diagnose` and `record_error` hold an internal `threading.Lock`.
 - **`Mode`** — flags: `REMOVEORIGINAL`, `VERBOSE`, `STRICT`, `QUIET`
 - **`Workspace`** (`fileidentification/workspace.py`) — the single run-scoped path module; a frozen dataclass holding `root_folder` + `tmp_dir`, built once via `Workspace.for_run(root, tmp_dir)` (validates root, normalizes a single-file target, creates the tmp dir). Derives `logjson` (`_log.json`), `poljson` (`_policies.json`), and `report_json(ymd)`, plus `abs_path` / `working_dir` / `removed_dest`. `write_logs` targets `ws.logjson` by default; the read-only `inspect` mode passes `ws.report_json(ymd)` so its report stays separate from a processing run.
 
@@ -107,6 +108,6 @@ Contains alternative policy sets (e.g. `dasch_policies.json`). `just setdasch` c
 `Workspace.for_run` creates the tmp dir: `__fileidentification/` inside the target directory, `<parent>/<stem>/` for a single-file target, or a custom `--tmp-dir` (which may be on another volume). It holds:
 - `_policies.json` — generated or read-in policies
 - `_log.json` — cumulative log of all processing (appended across runs)
-- `<yymmdd>_report.json` — written by the read-only `--inspect` mode instead of `_log.json`
+- `<yymmdd>_report.json` — the read-only `--inspect` mode's findings; `--inspect` also writes the bare scanned inventory to `_log.json` up front so a rerun reloads it instead of rescanning
 - `_REMOVED/` — corrupt or removed files
 - `<filename>_<pathhash[:6]>/` — per-file conversion working directories with converted file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,10 @@ just dasch          # DaSCH-specific: use dasch_policies.json as default, then d
 ### Data Flow
 
 1. `identify.py` — Typer CLI entrypoint; collects all flags and delegates to `FileHandler.run()`
-2. `FileHandler` (`fileidentification/filehandling.py`) — main orchestrator class; holds the processing state (`stack`, `policies`, `ba`, `log_tables`, `ws`, `mode`)
+2. `FileHandler` (`fileidentification/filehandling.py`) — main orchestrator class; holds the processing state (`stack`, `policies`, `ba`, `journal`, `ws`, `mode`)
 3. `_build_stack` populates `self.stack` — either reloading an existing `_log.json` or scanning the folder with pygfried; each file becomes an `SfInfo` object
-4. `_resolve_policies` sets `self.policies` (JSON keyed by PUID) — read from an existing file (`_read_policies`) or generated (`_gen_policies`)
-5. Tasks (integrity check, apply policies, convert, move) operate on the stack in sequence
+4. `_resolve_policies` sets `self.policies` (JSON keyed by PUID) via the `resolve_policies` module — read from the default location / an external file, or generated
+5. Tasks (integrity check, apply policies, convert, move) operate on the stack in sequence. `assert_integrity` and `apply_policies` skip files already marked `status.probed` / `status.applied`, so a re-run against a reloaded `_log.json` doesn't re-process or re-log them
 
 ### Key Models (`fileidentification/definitions/models.py`)
 

--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 
 from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
-from fileidentification.definitions.settings import Bin, FDMsg, PLMsg, PVErr
+from fileidentification.definitions.settings import Bin, FDMsg, LogLevel, PLMsg, PVErr
 
 
 class LogMsg(BaseModel):
@@ -15,6 +15,7 @@ class LogMsg(BaseModel):
 
     name: str
     msg: str
+    level: LogLevel = LogLevel.INFO
     timestamp: datetime | None = None
 
     def model_post_init(self, context: Any, /) -> None:
@@ -109,18 +110,21 @@ class RunJournal(BaseModel):
 
     def diagnose(self, sfinfo: SfInfo, severity: FDMsg, msg: LogMsg) -> None:
         """
-        Record a diagnostic for the console report: append `msg` to the SfInfo's processing_logs and bucket the
-        SfInfo under `severity`. The report prints each bucketed file's full processing_logs. Thread-safe.
+        Record a diagnostic for the console report: set `msg`'s level from `severity`, append it to the SfInfo's
+        processing_logs, and bucket the SfInfo under `severity`. The report prints each bucketed file's full
+        processing_logs. Thread-safe.
         """
+        msg.level = LogLevel.ERROR if severity == FDMsg.ERROR else LogLevel.WARNING
         with self._lock:
             sfinfo.processing_logs.append(msg)
             self.diagnostics.setdefault(severity.name, []).append(sfinfo)
 
     def record_error(self, msg: LogMsg, sfinfo: SfInfo, details: list[LogMsg] | None = None) -> None:
         """
-        Thread-safely append a processing error.
+        Thread-safely append a processing error (the summary is marked error-level).
         details are extra LogMsgs (e.g. the converter's output) recorded only in the "errors" copy and not printed.
         """
+        msg.level = LogLevel.ERROR
         with self._lock:
             self.processing_errors.append((msg, sfinfo, details or []))
 

--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -29,12 +29,16 @@ class Status(BaseModel):
     Processing state of a file.
     removed: moved to _REMOVED (corrupt or replaced by a conversion).
     pending: flagged for conversion but not yet converted.
-    added: this SfInfo is a conversion output that was added to the stack.
+    added: it is a conversion output that was added to the stack.
+    probed: integrity has been probed.
+    applied: policies have been applied.
     """
 
     removed: bool = False
     pending: bool = False
     added: bool = False
+    probed: bool = False
+    applied: bool = False
 
 
 # main metadata object where information is stored and added
@@ -283,7 +287,7 @@ def sfinfo2csv(sfinfo: SfInfo) -> dict[str, str | int]:
     if sfinfo.media_info:
         res["media_info"] = sfinfo.media_info[0].msg
     if sfinfo.processing_logs:
-        res["processing_logs"] = " ; ".join([el.msg for el in sfinfo.processing_logs])
+        res["processing_logs"] = " ; ".join([f"{el.level}: {el.msg}" for el in sfinfo.processing_logs])
     if sfinfo.derived_from:
         res["derived_from"] = f"{sfinfo.derived_from.filename}"
     return res

--- a/fileidentification/definitions/settings.py
+++ b/fileidentification/definitions/settings.py
@@ -84,6 +84,14 @@ class PLMsg(StrEnum):
     SKIPPED = "file format is not in policies, skipped"
 
 
+class LogLevel(StrEnum):
+    """severity of a LogMsg entry"""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
 class FDMsg(StrEnum):
     """file diagnostic message"""
 

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -124,8 +124,9 @@ class FileHandler:
             print_msg("\n --- Testing policies with a sample from the directory ---", self.mode.QUIET)
 
             for puid in puids:  # noqa: PLR1704
-                # we want the smallest file first for running the test
-                sample = self.ba.smallest_file(puid)
+                # test on a copy: convert_file mutates the sfinfo (logs, status.pending), and this is a
+                # diagnostic run that must not pollute the real stack object persisted to _log.json
+                sample = self.ba.smallest_file(puid).model_copy(deep=True)
                 secho(f"\n{puid}", fg=colors.YELLOW)
                 t_sfinfo, cmd, bin_log = convert_file(sample, self.policies, self.ws)
                 if t_sfinfo:
@@ -159,8 +160,12 @@ class FileHandler:
                     prog.advance(task)
 
     def inspect(self, to_csv: bool = False) -> None:
-        """Probe all active files and write a dated report JSON without modifying the source files."""
+        """
+        Probe all active files and write a dated report JSON without modifying the source files.
+        The scanned inventory is persisted to _log.json up front so a later run reloads it instead of rescanning.
+        """
         self.ws.poljson.unlink(missing_ok=True)
+        self.write_logs()  # persist the bare inventory so a rerun skips the pygfried scan
         active = [s for s in self.stack if s.is_active]
         self._run_parallel(
             active,

--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -160,10 +160,7 @@ class FileHandler:
                     prog.advance(task)
 
     def inspect(self, to_csv: bool = False) -> None:
-        """
-        Probe all active files and write a dated report JSON without modifying the source files.
-        The scanned inventory is persisted to _log.json up front so a later run reloads it instead of rescanning.
-        """
+        """Probe all active files and write a dated report JSON without modifying the source files."""
         self.ws.poljson.unlink(missing_ok=True)
         self.write_logs()  # persist the bare inventory so a rerun skips the pygfried scan
         active = [s for s in self.stack if s.is_active]
@@ -177,8 +174,8 @@ class FileHandler:
         self.write_logs(to_csv=to_csv, target=self.ws.report_json(datetime.now(UTC).strftime("%y%m%d")))
 
     def assert_integrity(self) -> None:
-        """Probe all active files: remove corrupt ones and rename files with extension mismatches."""
-        active = [s for s in self.stack if s.is_active]
+        """Probe active, not-yet-probed files: remove corrupt ones and rename files with extension mismatches."""
+        active = [s for s in self.stack if s.is_active and not s.status.probed]
         self._run_parallel(
             active,
             "Probing the files ...",
@@ -199,8 +196,8 @@ class FileHandler:
         self.remove_tmp(root_folder)
 
     def apply_policies(self) -> None:
-        """Evaluate the policy for every active file and mark those that need conversion as pending."""
-        active = [s for s in self.stack if s.is_active]
+        """Evaluate the policy for active, not-yet-applied files and mark those that need conversion as pending."""
+        active = [s for s in self.stack if s.is_active and not s.status.applied]
         self._run_parallel(
             active,
             "Applying policies ...",

--- a/fileidentification/tasks/conversion.py
+++ b/fileidentification/tasks/conversion.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pygfried
 
 from fileidentification.definitions.models import LogMsg, Policies, PolicyParams, SfInfo
-from fileidentification.definitions.settings import FPMsg
+from fileidentification.definitions.settings import FPMsg, LogLevel
 from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import MediaTool, tool_for
 
@@ -45,12 +45,14 @@ def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
 
         else:
             p_error = f" did expect {expected}, got {target_sfinfo.processed_as} instead"
-            sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{FPMsg.NOTEXPECTEDFMT}{p_error}"))
+            sfinfo.processing_logs.append(
+                LogMsg(name="filehandler", msg=f"{FPMsg.NOTEXPECTEDFMT}{p_error}", level=LogLevel.ERROR)
+            )
             target_sfinfo = None
 
     else:
         # conversion error, nothing to analyse
-        sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{FPMsg.CONVFAILED}"))
+        sfinfo.processing_logs.append(LogMsg(name="filehandler", msg=f"{FPMsg.CONVFAILED}", level=LogLevel.ERROR))
 
     return target_sfinfo
 

--- a/fileidentification/tasks/inspection.py
+++ b/fileidentification/tasks/inspection.py
@@ -1,5 +1,5 @@
 from fileidentification.definitions.models import LogMsg, Policies, RunJournal, SfInfo
-from fileidentification.definitions.settings import FMT2EXT, FDMsg, FPMsg
+from fileidentification.definitions.settings import FMT2EXT, FDMsg, FPMsg, LogLevel
 from fileidentification.tasks.os_tasks import remove
 from fileidentification.workspace import Workspace
 from fileidentification.wrappers.tools import MediaTool, tool_for, tool_from_mime
@@ -13,6 +13,7 @@ def assert_file_integrity(
     If the format has only one known extension, the rename is done automatically;
     otherwise it is flagged in the diagnostics for a manual rename.
     """
+    sfinfo.status.probed = True  # mark it so a re-run does not re-probe / re-log it
     res: FDMsg | None = inspect_file(sfinfo, policies, ws, journal, verbose)
     if res == FDMsg.ERROR:
         remove(sfinfo, ws, journal)
@@ -31,7 +32,8 @@ def inspect_file(sfinfo: SfInfo, policies: Policies, ws: Workspace, journal: Run
     Populates sfinfo.media_info and records any warnings / errors in the journal (which also logs them on the file).
     """
     if not sfinfo.processed_as:
-        msg = LogMsg(name="filehandler", msg=f"{FPMsg.PUIDFAIL} for {sfinfo.filename}")
+        msg = LogMsg(name="filehandler", msg=f"{FPMsg.PUIDFAIL} for {sfinfo.filename}", level=LogLevel.ERROR)
+        sfinfo.processing_logs.append(msg)  # make it persistent in _log.json
         journal.record_error(msg, sfinfo)
         return None
 

--- a/fileidentification/tasks/policies.py
+++ b/fileidentification/tasks/policies.py
@@ -159,6 +159,7 @@ def apply_policy(sfinfo: SfInfo, policies: Policies, ws: Workspace, journal: Run
     Files marked accepted=True are also checked for invalid A/V streams (fmt/199, fmt/569) and flagged for
     re-encoding if needed.
     """
+    sfinfo.status.applied = True  # mark it so a re-run does not re-evaluate / re-log it
     puid = sfinfo.processed_as
     if not puid:
         return

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 
 from fileidentification.definitions.models import PolicyParams
-from fileidentification.definitions.settings import Bin, FPMsg
+from fileidentification.definitions.settings import Bin, FPMsg, LogLevel
 from fileidentification.tasks import conversion as conv_mod
 from fileidentification.tasks.conversion import _add_media_info, _run_tool, _verify, convert_file
 from fileidentification.wrappers import tools
@@ -44,7 +44,7 @@ def test_missing_target_is_conversion_failure(tmp_path: Path) -> None:
     origin = make_sfinfo("sub/orig.jpg")
     result = _verify(tmp_path / "never-created.tif", origin, expected=["fmt/353"])
     assert result is None
-    assert any(FPMsg.CONVFAILED in log.msg for log in origin.processing_logs)
+    assert any(FPMsg.CONVFAILED in log.msg and log.level == LogLevel.ERROR for log in origin.processing_logs)
 
 
 def test_unexpected_format_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,6 +62,7 @@ def test_unexpected_format_is_rejected(tmp_path: Path, monkeypatch: pytest.Monke
     msgs = " ".join(log.msg for log in origin.processing_logs)
     assert FPMsg.NOTEXPECTEDFMT in msgs
     assert "fmt/353" in msgs and "fmt/43" in msgs  # expected vs. actual reported
+    assert origin.processing_logs[-1].level == LogLevel.ERROR  # unexpected-format is error-level
 
 
 def test_expected_format_is_accepted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -129,6 +129,37 @@ class TestConvertNoPending:
         assert all(not s.status.added for s in fh.stack)
 
 
+class TestSkipAlreadyProcessed:
+    """assert_integrity / apply_policies skip files already probed / applied on an earlier run (the marking
+    itself is done inside assert_file_integrity / apply_policy — see test_inspection / test_policies).
+    """
+
+    def test_assert_integrity_skips_already_probed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fh = FileHandler()
+        fresh, done = make_sfinfo("a.jpg"), make_sfinfo("b.jpg")
+        done.status.probed = True  # already probed on a previous run
+        fh.stack = [fresh, done]
+        seen: list[SfInfo] = []
+        monkeypatch.setattr("fileidentification.filehandling.assert_file_integrity", lambda s, *a: seen.append(s))
+        monkeypatch.setattr("fileidentification.filehandling.print_diagnostic", lambda **k: None)
+
+        fh.assert_integrity()
+
+        assert seen == [fresh]  # the already-probed file was not re-probed
+
+    def test_apply_policies_skips_already_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fh = FileHandler()
+        fresh, done = make_sfinfo("a.jpg"), make_sfinfo("b.jpg")
+        done.status.applied = True  # policies already applied on a previous run
+        fh.stack = [fresh, done]
+        seen: list[SfInfo] = []
+        monkeypatch.setattr("fileidentification.filehandling.apply_policy", lambda s, *a: seen.append(s))
+
+        fh.apply_policies()
+
+        assert seen == [fresh]  # the already-applied file was not re-evaluated
+
+
 class TestRunTriggersReencode:
     """run() with assert_integrity=True and apply=False must call _silently_reencode."""
 

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -408,7 +408,7 @@ class TestInspectMode:
         assert not fh.ws.poljson.exists()  # policies file deleted so report is standalone
         reports = list(fh.ws.tmp_dir.glob("*_report.json"))
         assert len(reports) == 1  # a dated report was written ...
-        assert not fh.ws.logjson.exists()  # ... instead of the canonical processing log
+        assert fh.ws.logjson.exists()  # ... and the inventory was persisted up front so a rerun skips the rescan
         assert probed == [active]  # removed files are skipped
 
 
@@ -466,3 +466,24 @@ class TestTestPolicies:
         out = capsys.readouterr().out
         assert "got fmt/5 instead" in out  # the failure reason from the sample's logs
         assert "stream error" in out  # the converter's own log
+
+    def test_does_not_mutate_the_original_sample(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # the diagnostic test runs on a copy: the real stack sample's logs and status must be untouched
+        fh = _fh_with_puids("fmt/199")
+        sample = make_sfinfo("small.mp4", puid="fmt/199", filesize=1)
+        fh.ba.puid_unique["fmt/199"] = [sample]
+        fh.policies = {
+            "fmt/199": PolicyParams(accepted=False, bin="ffmpeg", target_container="mp4", expected=["fmt/199"])
+        }
+
+        def failing(s: SfInfo, p: Policies, ws: Any) -> tuple[None, list[str], None]:
+            # mimic convert_file's side effects on the sfinfo it receives
+            s.processing_logs.append(LogMsg(name="filehandler", msg="conversion failed"))
+            s.status.pending = True
+            return None, ["cmd"], None
+
+        monkeypatch.setattr("fileidentification.filehandling.convert_file", failing)
+        fh._test_policies()
+
+        assert sample.processing_logs == []  # original left untouched (the copy absorbed the mutation)
+        assert sample.status.pending is False

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from fileidentification.definitions.models import PolicyParams, RunJournal
-from fileidentification.definitions.settings import Bin, FDMsg, FPMsg, REencMsg
+from fileidentification.definitions.settings import Bin, FDMsg, FPMsg, LogLevel, REencMsg
 from fileidentification.tasks import inspection as insp
 from fileidentification.tasks.inspection import _has_error, _rename, assert_file_integrity, inspect_file
 from fileidentification.wrappers import tools
@@ -78,6 +78,8 @@ class TestInspectFileOutcomes:
         assert inspect_file(s, {}, WS, lt, verbose=False) is None
         assert len(lt.processing_errors) == 1
         assert FPMsg.PUIDFAIL in lt.processing_errors[0][0].msg
+        # PUIDFAIL also persists on the file itself (error-level) so it survives a reload on a later run
+        assert any(FPMsg.PUIDFAIL in log.msg and log.level == LogLevel.ERROR for log in s.processing_logs)
 
     def test_empty_source_is_flagged_but_not_an_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(insp, "_has_error", lambda *a, **k: False)
@@ -229,3 +231,10 @@ class TestAssertFileIntegrity:
         s = make_sfinfo(puid="fmt/43")
         assert_file_integrity(s, {}, WS, RunJournal(), verbose=False)
         assert not calls["removed"] and not calls["renamed"]
+
+    def test_marks_probed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # so a later run skips it; set even when the verdict is clean
+        self._spy(monkeypatch, None)
+        s = make_sfinfo(puid="fmt/43")
+        assert_file_integrity(s, {}, WS, RunJournal(), verbose=False)
+        assert s.status.probed is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,7 @@ from fileidentification.definitions.models import (
     get_md5,
     sfinfo2csv,
 )
-from fileidentification.definitions.settings import FDMsg, PLMsg, PVErr
+from fileidentification.definitions.settings import FDMsg, LogLevel, PLMsg, PVErr
 from tests.conftest import make_sfinfo
 
 
@@ -31,6 +31,9 @@ class TestLogMsg:
     def test_timestamp_autoset(self) -> None:
         msg = LogMsg(name="x", msg="y")
         assert msg.timestamp is not None
+
+    def test_default_level_is_info(self) -> None:
+        assert LogMsg(name="x", msg="y").level == LogLevel.INFO
 
     def test_timestamp_preserved(self) -> None:
         from datetime import UTC, datetime
@@ -107,6 +110,7 @@ class TestRunJournal:
         assert j.diagnostics[FDMsg.ERROR.name] == [a, b]  # files bucketed under the severity
         assert a.processing_logs[-1].msg == "corrupt a"  # message logged on the file's single log list
         assert b.processing_logs[-1].msg == "corrupt b"
+        assert a.processing_logs[-1].level == LogLevel.ERROR  # ERROR severity -> error level
 
     def test_diagnose_uses_processing_logs_for_every_severity(self) -> None:
         # extension mismatch is no longer special-cased: it writes to processing_logs like the others
@@ -115,12 +119,14 @@ class TestRunJournal:
         j.diagnose(s, FDMsg.EXTMISMATCH, LogMsg(name="filehandler", msg="wrong ext"))
         assert j.diagnostics[FDMsg.EXTMISMATCH.name] == [s]
         assert s.processing_logs[-1].msg == "wrong ext"
+        assert s.processing_logs[-1].level == LogLevel.WARNING  # non-corrupt severity -> warning level
 
     def test_error_records_returns_copies_and_leaves_originals(self) -> None:
         j = RunJournal()
         s = make_sfinfo()
         msg = LogMsg(name="x", msg="boom")
         j.record_error(msg, s)
+        assert msg.level == LogLevel.ERROR  # record_error marks the summary error-level
         dumped = j.error_records()
         assert dumped is not None
         assert msg in dumped[0].processing_logs  # error recorded in the returned (errors) copy

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -252,7 +252,7 @@ class TestSfInfo2Csv:
         s.processing_logs.append(LogMsg(name="ffmpeg", msg="w2"))
         row = sfinfo2csv(s)
         assert row["status"] == "pending"
-        assert row["processing_logs"] == "w1 ; w2"
+        assert row["processing_logs"] == "info: w1 ; info: w2"  # each entry is prefixed with its level
 
     def test_media_info_and_derived_from(self) -> None:
         origin = make_sfinfo("sub/orig.jpg")
@@ -262,5 +262,5 @@ class TestSfInfo2Csv:
         s.derived_from = origin
         row = sfinfo2csv(s)
         assert row["media_info"] == "TIFF 10x10"
-        assert row["processing_logs"] == "converted"
+        assert row["processing_logs"] == "info: converted"
         assert row["derived_from"] == "sub/orig.jpg"

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -55,6 +55,13 @@ def test_accepted_file_stays() -> None:
     assert not s.status.pending
 
 
+def test_marks_applied() -> None:
+    # so a later run skips it
+    s = make_sfinfo()
+    apply_policy(s, {"fmt/43": ACCEPTED}, WS, RunJournal(), strict=False)
+    assert s.status.applied is True
+
+
 def test_not_accepted_marks_pending() -> None:
     s = make_sfinfo()
     apply_policy(s, {"fmt/43": CONVERT}, WS, RunJournal(), strict=False)


### PR DESCRIPTION
Follow-ups on the logging model, in two commits.

## `a260a79` — LogMsg severity level + test/inspect hygiene
- **`LogMsg.level`** — new `LogLevel` (info/warning/error, default info). Set where severity is known: `RunJournal.diagnose` maps the `FDMsg` severity, `record_error` marks the summary error, and the conversion-failure logs (`CONVFAILED`, `NOTEXPECTEDFMT`) are error-level. Old `_log.json` entries reload as info.
- **`_test_policies` on a deep copy** — the policy test runs against `sample.model_copy(deep=True)`, so the diagnostic run can't pollute the real stack object's logs / `status.pending` in `_log.json`.
- **`inspect` persists the inventory** — writes the bare `_log.json` up front so a rerun reloads instead of rescanning with pygfried; the dated report is still written at the end.

## `692d3b5` — persist PUIDFAIL + skip already-processed files on a re-run
- **PUIDFAIL persists** — an undetected filetype was recorded only via `record_error` (kept off the file), so it was lost when a later run reloaded from `_log.json`. It's a durable property, so it's now also logged (error-level) on `processing_logs`.
- **`status.probed` / `status.applied`** — `assert_file_integrity` / `apply_policy` set them per file; `assert_integrity` / `apply_policies` skip files already marked. Stops a repeated `-i` / `-a` from re-probing / re-evaluating (and re-logging) files reloaded from `_log.json`. `convert` stays ungated so a failed conversion still retries. `--inspect` is unaffected (it never persists findings to `_log.json`).

## Checks
`ruff`, `mypy` (strict) clean; 178 tests pass (`pytest -m "not docker"`).

## Pre-merge note
`sfinfo2csv` now prefixes each log entry with its level (`info: ...`) — a small CSV format change. Docker-marked tests weren't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)