### PR TITLE
refactor: converted filename tmp relative

### DIFF
--- a/fileidentification/definitions/models.py
+++ b/fileidentification/definitions/models.py
@@ -46,7 +46,8 @@ class SfInfo(BaseModel):
     """file info object mapped from siegfried output, gets extended while processing."""
 
     # output from siegfried
-    filename: Path
+    filename: Path  # portable, relative to root_folder — except a converted file awaiting move (dest set),
+    # whose filename is its working-dir location relative to tmp_dir until move_tmp relocates it
     filesize: int
     modified: str
     errors: str
@@ -59,7 +60,7 @@ class SfInfo(BaseModel):
     processing_logs: list[LogMsg] = Field(default_factory=list[LogMsg])
     # if converted
     derived_from: Self | None = None
-    dest: Path | None = None
+    dest: Path | None = None  # future home dir (relative to root_folder); set until move_tmp relocates the file
 
     def model_post_init(self, context: Any, /) -> None:
         """Derive the fields not provided by siegfried: status, processed_as, md5"""

--- a/fileidentification/tasks/conversion.py
+++ b/fileidentification/tasks/conversion.py
@@ -23,7 +23,7 @@ def _add_media_info(sfinfo: SfInfo, tool: MediaTool | None, path: Path) -> None:
         sfinfo.media_info.append(media_info)
 
 
-def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
+def _verify(target: Path, sfinfo: SfInfo, expected: list[str], ws: Workspace) -> SfInfo | None:
     """
     Identify the converted file with pygfried and verify it matches the expected format.
     Returns an SfInfo for the new file (linked back to the origin via derived_from) on success, or None if the
@@ -36,10 +36,10 @@ def _verify(target: Path, sfinfo: SfInfo, expected: list[str]) -> SfInfo | None:
         target_sfinfo = SfInfo(**pygfried.identify(f"{target}", detailed=True)["files"][0])  # type: ignore[arg-type]
         # only add postprocessing information if conversion was successful
         if target_sfinfo.processed_as in expected:
+            # filename points at where the file physically is (relative to tmp_dir, in its working dir);
+            # dest holds the future home next to the original. move_tmp relocates it and rewrites filename.
+            target_sfinfo.filename = target.relative_to(ws.tmp_dir)
             target_sfinfo.dest = sfinfo.filename.parent
-            # normalize the converted file to its portable relative home straight away; the physical file still
-            # sits in the working dir until move_tmp (reachable via ws.working_file(derived_from, filename.name)).
-            target_sfinfo.filename = sfinfo.filename.parent / target.name
             target_sfinfo.derived_from = sfinfo
             sfinfo.status.pending = False
 
@@ -98,7 +98,7 @@ def convert_file(sfinfo: SfInfo, policies: Policies, ws: Workspace) -> tuple[SfI
         processing_log = LogMsg(name=f"{args.bin}", msg=logtext)
 
     # create an SfInfo for target and verify output, add codec and processing logs
-    target_sfinfo = _verify(target_path, sfinfo, args.expected)
+    target_sfinfo = _verify(target_path, sfinfo, args.expected, ws)
     if target_sfinfo:
         _add_media_info(target_sfinfo, tool, target_path)
         if processing_log:

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -34,9 +34,10 @@ def move_tmp(
                 derived_from = next(sfi for sfi in stack if sfi.filename == sfinfo.derived_from.filename)  # type: ignore[union-attr]
                 if ws.abs_path(derived_from.filename).is_file():
                     remove(derived_from, ws, journal)
-            # the converted file still sits in its working dir; its final home is abs_path(filename)
-            source = ws.working_file(sfinfo.derived_from.filename, sfinfo.filename.name)  # type: ignore[union-attr]
-            abs_dest = ws.abs_path(sfinfo.filename)
+            # filename is the converted file's location in the working dir (relative to tmp_dir); dest is its
+            # future home dir next to the original
+            source = ws.tmp_dir / sfinfo.filename
+            abs_dest = ws.abs_path(sfinfo.dest / sfinfo.filename.name)
             # append hash to filename if the path already exists
             if abs_dest.is_file():
                 abs_dest = abs_dest.parent / f"{sfinfo.filename.stem}_{sfinfo.md5[:6]}{sfinfo.filename.suffix}"

--- a/fileidentification/workspace.py
+++ b/fileidentification/workspace.py
@@ -79,10 +79,6 @@ class Workspace:
         path_hash = hashlib.md5(str(filename).encode()).hexdigest()[:6]  # noqa: S324
         return self.tmp_dir / f"{filename.name}_{path_hash}"
 
-    def working_file(self, origin_filename: Path, output_name: str) -> Path:
-        """Where a converted file physically sits before it is moved: inside its origin's working dir."""
-        return self.working_dir(origin_filename) / output_name
-
     def removed_dest(self, filename: Path) -> Path:
         """Location under _REMOVED for a corrupt / replaced file (the relative subpath is preserved)."""
         return self.tmp_dir / RMV_DIR / filename

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -42,7 +42,7 @@ def _patch_identify(monkeypatch: pytest.MonkeyPatch, target: Path, puid: str) ->
 def test_missing_target_is_conversion_failure(tmp_path: Path) -> None:
     """No output file on disk -> conversion failed, original logs CONVFAILED."""
     origin = make_sfinfo("sub/orig.jpg")
-    result = _verify(tmp_path / "never-created.tif", origin, expected=["fmt/353"])
+    result = _verify(tmp_path / "never-created.tif", origin, expected=["fmt/353"], ws=make_ws(tmp_path, tmp_path))
     assert result is None
     assert any(FPMsg.CONVFAILED in log.msg and log.level == LogLevel.ERROR for log in origin.processing_logs)
 
@@ -55,7 +55,7 @@ def test_unexpected_format_is_rejected(tmp_path: Path, monkeypatch: pytest.Monke
 
     origin = make_sfinfo("sub/orig.jpg")
     origin.status.pending = True
-    result = _verify(target, origin, expected=["fmt/353"])
+    result = _verify(target, origin, expected=["fmt/353"], ws=make_ws(tmp_path, tmp_path))
 
     assert result is None
     assert origin.status.pending is True  # left pending: conversion did not succeed
@@ -73,12 +73,14 @@ def test_expected_format_is_accepted(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     origin = make_sfinfo("sub/orig.jpg")
     origin.status.pending = True
-    result = _verify(target, origin, expected=["fmt/152", "fmt/353"])  # matches the second listed PUID
+    # tmp_dir = tmp_path, so the target's tmp-relative location is just "orig.tif"
+    result = _verify(target, origin, expected=["fmt/152", "fmt/353"], ws=make_ws(tmp_path, tmp_path))
 
     assert result is not None
     assert result.processed_as == "fmt/353"
     assert result.derived_from is origin
-    assert result.dest == Path("sub")  # placed next to the original
+    assert result.filename == Path("orig.tif")  # points at its physical location relative to tmp_dir
+    assert result.dest == Path("sub")  # future home dir, next to the original
     assert origin.status.pending is False  # original is now resolved
 
 
@@ -120,16 +122,17 @@ class TestAddMediaInfo:
 
 def test_convert_file_strips_abs_paths_from_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """convert_file removes root_folder/tdir prefixes from the tool log before attaching it."""
+    root, tdir = tmp_path / "root", tmp_path / "tdir"
+    ws = make_ws(root, tdir)
     origin = make_sfinfo("sub/orig.jpg", puid="fmt/43")
     origin.status.pending = True
-    ws = make_ws("/root", "/tmp/tdir")
 
-    target = tmp_path / "orig.tif"
+    target = tdir / "orig.tif"  # the converted file sits under tmp_dir
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(b"data")
     _patch_identify(monkeypatch, target, puid="fmt/353")
-    monkeypatch.setattr(
-        conv_mod, "_run_tool", lambda s, a, tool, ws: (target, "the cmd", "/root/sub/orig.jpg -> /tmp/tdir/out")
-    )
+    logtext = f"{root}/sub/orig.jpg -> {tdir}/out"
+    monkeypatch.setattr(conv_mod, "_run_tool", lambda s, a, tool, ws: (target, "the cmd", logtext))
     monkeypatch.setattr(conv_mod, "_add_media_info", lambda s, t, p: None)
 
     policies = {"fmt/43": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])}

--- a/tests/test_os_tasks.py
+++ b/tests/test_os_tasks.py
@@ -49,9 +49,8 @@ class TestMoveTmp:
         root/sub/orig.jpg                             original file
         tdir/orig.jpg_<hash>/orig.tif                 converted file, in its working dir (to be moved)
 
-        The converted SfInfo's filename is already its relative home (sub/orig.tif); the physical file
-        lives at ws.working_file(original.filename, "orig.tif"). Returns (stack, original, converted,
-        policies, root, ws).
+        The converted SfInfo's filename is its physical location relative to tmp_dir (its working dir);
+        dest is the future home dir (sub). Returns (stack, original, converted, policies, root, ws).
         """
         root = tmp_path / "root"
         (root / "sub").mkdir(parents=True)
@@ -61,14 +60,15 @@ class TestMoveTmp:
 
         original = make_sfinfo("sub/orig.jpg", puid="fmt/43", md5="aaaaaa")
 
-        converted = make_sfinfo("sub/orig.tif", puid="fmt/353", md5=conv_md5, mime="image/tiff")
-        converted.dest = Path("sub")
-        converted.derived_from = original
-
-        # place the physical converted file where move_tmp will look for it
-        workfile = ws.working_file(original.filename, "orig.tif")
+        # place the physical converted file in the origin's working dir under tmp_dir
+        workfile = ws.working_dir(original.filename) / "orig.tif"
         workfile.parent.mkdir(parents=True)
         workfile.write_bytes(b"converted")
+
+        converted = make_sfinfo("sub/orig.tif", puid="fmt/353", md5=conv_md5, mime="image/tiff")
+        converted.filename = workfile.relative_to(ws.tmp_dir)  # tmp-relative physical location
+        converted.dest = Path("sub")
+        converted.derived_from = original
 
         policies = {
             "fmt/43": PolicyParams(
@@ -83,7 +83,7 @@ class TestMoveTmp:
 
     def test_moves_converted_file_next_to_original(self, tmp_path: Path) -> None:
         stack, original, converted, policies, root, ws = self._scenario(tmp_path)
-        workdir = ws.working_file(original.filename, "orig.tif").parent
+        workdir = ws.working_dir(original.filename)
 
         moved = move_tmp(stack, ws, policies, RunJournal(), remove_original=False)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -49,13 +49,6 @@ class TestWorkingDir:
         assert ws.working_dir(Path("a/clip.mp4")) != ws.working_dir(Path("b/clip.mp4"))
 
 
-class TestWorkingFile:
-    def test_inside_origin_working_dir(self) -> None:
-        ws = _ws()
-        origin = Path("sub/orig.jpg")
-        assert ws.working_file(origin, "orig.tif") == ws.working_dir(origin) / "orig.tif"
-
-
 class TestRemovedDest:
     def test_under_removed_preserving_subpath(self) -> None:
         assert _ws().removed_dest(Path("sub/a.jpg")) == Path("/data/root/__fileidentification/_REMOVED/sub/a.jpg")


### PR DESCRIPTION
## Problem
`_verify` set a converted file's `filename` to an *aspirational* root-relative home (`sub/orig.tif`) while the file physically sat in its working dir. That name pointed at a location that didn't exist yet, and forced `move_tmp` to reconstruct the actual source by re-hashing the origin's path via `ws.working_file(derived_from, filename.name)`.

## Change
Store where the file actually is:
- **`_verify`** (now takes `ws`): `filename = target.relative_to(ws.tmp_dir)` — its working-dir location; `dest` still holds the future home dir.
- **`move_tmp`**: source is read directly (`ws.tmp_dir / filename`) and moved to `ws.abs_path(dest / filename.name)`, then `filename` is rewritten to the root-relative home.
- **`Workspace.working_file`**: dead, removed.

Net −6 lines and the origin↔working-dir hash dance is gone.

## Tradeoff (documented)
`SfInfo.filename` is root-relative **except** for a converted file awaiting move (`dest` set), where it is tmp-relative. This is cleanly gated by `is_active` — such files are excluded from every active-file loop; only `move_tmp` consumes them — and it's noted in the `SfInfo.filename` / `dest` field comments.

## Checks
`ruff`, `mypy` (strict) clean; 177 tests pass (`pytest -m "not docker"`).

## Pre-merge note
Docker-marked tests (real conversions through `move_tmp`) weren't run here — worth a docker run before merge since this touches the physical move path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)