### PR TITLE
refactor: pass a Mode to run()

### DIFF
--- a/fileidentification/filehandling.py
+++ b/fileidentification/filehandling.py
@@ -268,35 +268,29 @@ class FileHandler:
     def run(  # noqa: C901 flat task orchestration; complexity is from the flag branches, not nesting
         self,
         root_folder: Path | str,
-        assert_integrity: bool = True,
-        apply: bool = True,
-        remove_tmp: bool = True,
+        mode: Mode,
+        *,
+        assert_integrity: bool = False,
+        apply: bool = False,
+        remove_tmp: bool = False,
         convert: bool = False,
         policies_path: Path | None = None,
         blank: bool = False,
         extend: bool = False,
         test_puid: str | None = None,
         test_policies: bool = False,
-        remove_original: bool = False,
-        mode_strict: bool = False,
-        mode_verbose: bool = True,
-        mode_quiet: bool = True,
         to_csv: bool = False,
         tmp_dir: Path | None = None,
         inspect: bool = False,
     ) -> None:
         root_folder = Path(root_folder)
+        self.mode = mode
         # resolve the run's paths (validates the root, normalizes a single-file target, creates the tmp dir)
         try:
             self.ws = Workspace.for_run(root_folder, tmp_dir)
         except ValueError:
             print_root_not_found()
             raise Exit(1) from None
-        # set the mode
-        self.mode.REMOVEORIGINAL = remove_original
-        self.mode.VERBOSE = mode_verbose
-        self.mode.STRICT = mode_strict
-        self.mode.QUIET = mode_quiet
         # generate a list of SfInfo objects out of the target folder
         self._build_stack(root_folder)
         # the stack is now complete; from here on, persist it on any failure so a restart

--- a/identify.py
+++ b/identify.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 import typer
 
+from fileidentification.definitions.models import Mode
 from fileidentification.filehandling import FileHandler
 
 
@@ -97,9 +98,11 @@ def main(
     to_csv: Annotated[bool, typer.Option("--csv", help="get a csv out of the log.json.")] = False,
     inspect: Annotated[bool, typer.Option("--inspect", help="inspect the files without any modification.")] = False,
 ) -> None:
+    mode = Mode(REMOVEORIGINAL=remove_original, VERBOSE=mode_verbose, STRICT=mode_strict, QUIET=mode_quiet)
     fh = FileHandler()
     fh.run(
         root_folder=root_folder,
+        mode=mode,
         assert_integrity=assert_integrity,
         apply=apply,
         convert=convert,
@@ -110,10 +113,6 @@ def main(
         extend=extend,
         test_puid=test_puid,
         test_policies=test_policies,
-        remove_original=remove_original,
-        mode_strict=mode_strict,
-        mode_verbose=mode_verbose,
-        mode_quiet=mode_quiet,
         to_csv=to_csv,
         inspect=inspect,
     )

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -11,7 +11,7 @@ from typing import Any, Self
 
 import pytest
 
-from fileidentification.definitions.models import LogMsg, Policies, PolicyParams, SfInfo
+from fileidentification.definitions.models import LogMsg, Mode, Policies, PolicyParams, SfInfo
 from fileidentification.filehandling import FileHandler
 from tests.conftest import fake_identify_payload, make_sfinfo, make_ws
 
@@ -176,7 +176,7 @@ class TestRunTriggersReencode:
         monkeypatch.setattr(fh, "remove_tmp", lambda root: order.append("remove_tmp"))
         monkeypatch.setattr(fh, "write_logs", lambda to_csv=False: order.append("logs"))
 
-        fh.run(root_folder=tmp_path, assert_integrity=True, apply=False, remove_tmp=False)
+        fh.run(root_folder=tmp_path, mode=Mode(), assert_integrity=True, apply=False, remove_tmp=False)
 
         assert "assert" in order
         assert "reencode" in order
@@ -194,7 +194,7 @@ class TestRunTriggersReencode:
         monkeypatch.setattr(fh, "remove_tmp", lambda root: None)
         monkeypatch.setattr(fh, "write_logs", lambda to_csv=False: None)
 
-        fh.run(root_folder=tmp_path, assert_integrity=True, apply=True, remove_tmp=False)
+        fh.run(root_folder=tmp_path, mode=Mode(), assert_integrity=True, apply=True, remove_tmp=False)
 
         assert "reencode" not in order
         assert "apply" in order


### PR DESCRIPTION
Deepening #2 from the round-2 architecture review — the **targeted** scope (reuse the existing `Mode`, fix the defaults), deliberately not the full `RunOptions` object (one production caller → that would've been a lateral move, per ADR-0002's lesson).

## What
- **Reuse `Mode`.** `run()` took four loose flags (`remove_original`, `mode_strict`, `mode_verbose`, `mode_quiet`) and unpacked them one-by-one into `self.mode`, shadowing the `Mode` value object built for exactly that grouping. `identify.py` now assembles the `Mode` and passes it; `run()` takes `mode: Mode` and assigns it directly — **4 params + 4 assignments → 1**.
- **Fix misleading defaults.** `run()` declared `assert_integrity`/`apply`/`remove_tmp`/`verbose`/`quiet` as `True`, but the CLI always passed `False` — the defaults were dead and misrepresented a bare run. The remaining task flags now default to `False`, matching the CLI.
- **Keyword-only task flags** (`*`) so the run of same-typed booleans can't be passed positionally (every caller already used keywords — zero call-site change).

`run()`'s interface: **16 params → 12**, and the four that left are the ones `Mode` already owns.

## Checks
`ruff`, `mypy` (strict) clean; 176 unit + **15 docker e2e** all pass locally — the e2e drive the real CLI flags (`-i`/`-v`/`-a`/`-s`/`-x`) through the new `Mode` assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)