### PR TITLE
fix: sipi guard skips to-be-converted files; prune_empty_dirs keeps its root

### DIFF
--- a/fileidentification/tasks/inspection.py
+++ b/fileidentification/tasks/inspection.py
@@ -64,14 +64,16 @@ def inspect_file(
         return FDMsg.EXTMISMATCH
 
     # DaSCH sipi guard: an image magick considers fine is only kept if sipi can decode it too
-    if sipi_guard and tool is not None and tool.bin == Bin.MAGICK and _sipi_guard(sfinfo, ws, journal):
+    if sipi_guard and tool is not None and tool.bin == Bin.MAGICK and _sipi_guard(sfinfo, ws, journal, policies):
         return FDMsg.ERROR
 
     return None
 
 
-def _sipi_guard(sfinfo: SfInfo, ws: Workspace, journal: RunJournal) -> bool:
-    """DaSCH guard: return True (file treated as corrupt) if sipi cannot decode it. Probes via the sipi MediaTool."""
+def _sipi_guard(sfinfo: SfInfo, ws: Workspace, journal: RunJournal, policies: Policies) -> bool:
+    """Return True if sipi cannot decode it. Return False if the file needs to be converted."""
+    if sfinfo.processed_as in policies and not policies[sfinfo.processed_as].accepted:
+        return False
     tool = tool_for(Bin.SIPI)
     result = tool.probe(ws.abs_path(sfinfo.filename), verbose=False) if tool else None
     if result and result.is_corrupt:

--- a/fileidentification/tasks/os_tasks.py
+++ b/fileidentification/tasks/os_tasks.py
@@ -7,11 +7,11 @@ from fileidentification.workspace import Workspace
 
 
 def prune_empty_dirs(root: Path) -> None:
-    """Recursively remove empty directories under `root` (bottom-up); no-op if `root` isn't a directory."""
+    """Recursively remove empty directories *under* `root` (bottom-up), keeping `root` itself; no-op if not a dir."""
     if not root.is_dir():
         return
     for path, _, _ in os.walk(root, topdown=False):
-        if not os.listdir(path):  # noqa: PTH208
+        if Path(path) != root and not os.listdir(path):  # noqa: PTH208
             Path(path).rmdir()
 
 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -279,9 +279,9 @@ class TestSipiGuard:
     def test_helper_flags_and_diagnoses_on_sipi_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake = SimpleNamespace(probe=lambda path, verbose: ProbeResult(is_corrupt=True, warnings="sipi boom", specs=""))
         monkeypatch.setattr(insp, "tool_for", lambda _bin: fake)
-        s = make_sfinfo("i.gif", puid="fmt/4")
+        s = make_sfinfo("i.gif", puid="fmt/4")  # not in policies -> kept -> guarded
         journal = RunJournal()
-        assert _sipi_guard(s, make_ws(), journal) is True
+        assert _sipi_guard(s, make_ws(), journal, {}) is True
         assert FDMsg.ERROR.name in journal.diagnostics  # bucketed for the report
         assert any("sipi boom" in log.msg for log in s.processing_logs)
 
@@ -289,4 +289,13 @@ class TestSipiGuard:
         fake = SimpleNamespace(probe=lambda path, verbose: ProbeResult(is_corrupt=False, warnings="", specs=""))
         monkeypatch.setattr(insp, "tool_for", lambda _bin: fake)
         s = make_sfinfo("i.jp2", puid="x-fmt/392")
-        assert _sipi_guard(s, make_ws(), RunJournal()) is False
+        assert _sipi_guard(s, make_ws(), RunJournal(), {}) is False
+
+    def test_helper_skips_files_that_will_be_converted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # sipi would flag it, but a to-be-converted file (accepted=False) is excluded: sipi gets the output,
+        # and quarantining it here would remove it before the conversion runs (e.g. Canon CRW fmt/592 -> tif)
+        fake = SimpleNamespace(probe=lambda path, verbose: ProbeResult(is_corrupt=True, warnings="x", specs=""))
+        monkeypatch.setattr(insp, "tool_for", lambda _bin: fake)
+        s = make_sfinfo("raw.crw", puid="fmt/592")
+        convert = {"fmt/592": PolicyParams(accepted=False, bin="magick", target_container="tif", expected=["fmt/353"])}
+        assert _sipi_guard(s, make_ws(), RunJournal(), convert) is False

--- a/tests/test_os_tasks.py
+++ b/tests/test_os_tasks.py
@@ -6,7 +6,7 @@ import pytest
 
 from fileidentification.definitions.models import PolicyParams, RunJournal, SfInfo
 from fileidentification.definitions.settings import RMV_DIR
-from fileidentification.tasks.os_tasks import move_tmp, remove
+from fileidentification.tasks.os_tasks import move_tmp, prune_empty_dirs, remove
 from fileidentification.workspace import Workspace
 from tests.conftest import make_sfinfo, make_ws
 
@@ -155,3 +155,12 @@ class TestMoveTmp:
 
         assert lt.processing_errors  # the OSError was captured
         assert not converted.status.added  # move did not complete
+
+
+class TestPruneEmptyDirs:
+    def test_keeps_an_empty_root(self, tmp_path: Path) -> None:
+        # regression: prune must not delete its own root -- write_logs writes _log.json into the tmp dir afterwards
+        root = tmp_path / "tmp"
+        root.mkdir()
+        prune_empty_dirs(root)
+        assert root.is_dir()


### PR DESCRIPTION
Two independent fixes on top of the sipi verify guard (#121), one commit each.

## 1. Skip the sipi guard for files that will be converted
The guard runs during inspection, **before** the convert phase. A file whose policy converts it (`accepted=False`) must be excluded — sipi will receive the converted output, not the original, and quarantining it here removes it before the conversion can run. Concretely: a Canon CRW (`fmt/593` → tif in `default_policies`) that sipi can't decode was being quarantined during `-i`, so it never got converted. `_sipi_guard` now takes the policies and returns `False` for a to-be-converted file.

## 2. `prune_empty_dirs` must not delete its own root
`move_tmp` calls `prune_empty_dirs(ws.tmp_dir)`; `os.walk(topdown=False)` yields the root last, so an **empty** tmp dir was deleted — and the subsequent `write_logs` then crashed with `FileNotFoundError` writing `_log.json`. This is independent of sipi: it hits any run whose tmp dir is empty at move time, e.g. `-i -p <external-policies>` (which writes no `_policies.json`) with nothing removed/converted — the DaSCH path. Fix keeps the root and prunes only its children.

## Tests
- `_sipi_guard` unit test for the conversion-exclusion.
- `prune_empty_dirs` regression: an empty root survives.

Verified: ruff, ruff format, mypy (strict), 198 unit, 17 docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)